### PR TITLE
feat(oracle): Layer 1 — Agent Analytics + OTel instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: uv python install
 
       - name: Install workspace dependencies
-        run: uv sync --all-packages
+        run: uv sync --all-packages --all-extras
 
       - name: Run tests
         run: uv run --package ${{ matrix.package.name }} pytest ${{ matrix.package.test_path }} -v
@@ -52,7 +52,7 @@ jobs:
         run: uv python install
 
       - name: Install workspace dependencies
-        run: uv sync --all-packages
+        run: uv sync --all-packages --all-extras
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,9 @@ jobs:
 
       - name: Ruff format check
         run: uv run ruff format --check .
+
+      - name: Mypy (oracle)
+        run: uv run mypy packages/oracle/src
+
+      - name: Mypy (shared)
+        run: uv run mypy packages/shared/src

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,31 @@
+pre-commit:
+  parallel: true
+  commands:
+    ruff-fix:
+      glob: "*.py"
+      run: uv run ruff check --fix {staged_files} && git add {staged_files}
+      stage_fixed: true
+    ruff-format:
+      glob: "*.py"
+      run: uv run ruff format {staged_files} && git add {staged_files}
+      stage_fixed: true
+
+pre-push:
+  parallel: false
+  commands:
+    ruff-check:
+      glob: "*.py"
+      run: uv run ruff check .
+    ruff-format-check:
+      glob: "*.py"
+      run: uv run ruff format --check .
+    mypy-oracle:
+      run: uv run mypy packages/oracle/src
+    mypy-shared:
+      run: uv run mypy packages/shared/src
+    test-shared:
+      run: uv run --package mcp-shared pytest packages/shared/tests/ -q
+    test-oracle:
+      run: uv run --package project-oracle pytest packages/oracle/tests/ -q
+    test-webhook:
+      run: uv run --package github-webhook-mcp pytest packages/webhook/tests/ -q

--- a/packages/oracle/features/environment.py
+++ b/packages/oracle/features/environment.py
@@ -5,11 +5,11 @@ import tempfile
 from pathlib import Path
 
 
-def before_scenario(context, scenario):
+def before_scenario(context, _scenario):
     context.tmp_dir = Path(tempfile.mkdtemp())
     context.project_root = None
     context.last_response = None
 
 
-def after_scenario(context, scenario):
+def after_scenario(context, _scenario):
     shutil.rmtree(context.tmp_dir, ignore_errors=True)

--- a/packages/oracle/features/steps/ask_steps.py
+++ b/packages/oracle/features/steps/ask_steps.py
@@ -3,7 +3,6 @@
 import asyncio
 
 from behave import given, then, when
-
 from oracle.cache.command_cache import CommandCache
 from oracle.cache.git_cache import GitCache
 from oracle.project import ProjectState, StackInfo

--- a/packages/oracle/features/steps/command_steps.py
+++ b/packages/oracle/features/steps/command_steps.py
@@ -1,7 +1,6 @@
 """Step definitions for command result caching scenarios."""
 
 from behave import given, when
-
 from oracle.cache.command_cache import CommandCache, CommandNotAllowedError
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/features/steps/file_steps.py
+++ b/packages/oracle/features/steps/file_steps.py
@@ -1,7 +1,6 @@
 """Step definitions for file content caching scenarios."""
 
 from behave import given, then, when
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
 from oracle.tools.forget import handle_oracle_forget

--- a/packages/oracle/features/steps/git_steps.py
+++ b/packages/oracle/features/steps/git_steps.py
@@ -3,7 +3,6 @@
 import subprocess
 
 from behave import given, when
-
 from oracle.cache.git_cache import GitCache
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/pyproject.toml
+++ b/packages/oracle/pyproject.toml
@@ -21,8 +21,6 @@ dev = [
     "coverage[toml]>=7.0",
     "hypothesis>=6.100",
     "behave>=1.2",
-    "ruff>=0.9",
-    "mypy>=1.14",
 ]
 
 [project.scripts]
@@ -63,15 +61,3 @@ cache = true
 workers = "auto"
 max-pardons-pct = 0.0
 
-[tool.ruff]
-target-version = "py312"
-line-length = 100
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM"]
-
-[tool.mypy]
-python_version = "3.12"
-strict = true
-warn_return_any = true
-warn_unused_configs = true

--- a/packages/oracle/src/oracle/analytics/__init__.py
+++ b/packages/oracle/src/oracle/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics subsystem."""

--- a/packages/oracle/src/oracle/analytics/__init__.py
+++ b/packages/oracle/src/oracle/analytics/__init__.py
@@ -1,1 +1,7 @@
-"""Analytics subsystem."""
+"""Analytics subsystem — tracks agent behavior patterns."""
+
+from oracle.analytics.aggregator import SessionAggregator
+from oracle.analytics.insights import InsightsGenerator
+from oracle.analytics.tracker import AnalyticsTracker
+
+__all__ = ["AnalyticsTracker", "InsightsGenerator", "SessionAggregator"]

--- a/packages/oracle/src/oracle/analytics/aggregator.py
+++ b/packages/oracle/src/oracle/analytics/aggregator.py
@@ -1,0 +1,53 @@
+"""SessionAggregator — computes session profiles from agent_log data."""
+
+from __future__ import annotations
+
+import json
+
+from mcp_shared.telemetry import get_tracer
+
+from oracle.storage.store import OracleStore
+
+_tracer = get_tracer("oracle.analytics.aggregator")
+
+
+class SessionAggregator:
+    """Aggregates agent_log rows into a session profile."""
+
+    def __init__(self, store: OracleStore) -> None:
+        self._store = store
+
+    def finalize_session(self, session_id: str) -> None:
+        """Compute and store a profile for the given session.
+
+        No-op if the session has no logged interactions.
+        """
+        with _tracer.start_as_current_span("analytics.finalize_session") as span:
+            span.set_attribute("session_id", session_id)
+            rows = self._store.get_session_log(session_id)
+
+            if not rows:
+                return
+
+            tool_counts: dict[str, int] = {}
+            file_paths: set[str] = set()
+            cache_hits = 0
+
+            for row in rows:
+                tool = row["tool_name"]
+                tool_counts[tool] = tool_counts.get(tool, 0) + 1
+                if row["cache_hit"]:
+                    cache_hits += 1
+                if tool == "oracle_read" and row["input"]:
+                    file_paths.add(row["input"])
+
+            self._store.upsert_session_profile(
+                session_id=session_id,
+                started_at=float(rows[0]["ts"]),
+                ended_at=float(rows[-1]["ts"]),
+                tool_counts=json.dumps(tool_counts),
+                files_touched=len(file_paths),
+                cache_hit_rate=cache_hits / len(rows),
+            )
+            span.set_attribute("files_touched", len(file_paths))
+            span.set_attribute("cache_hit_rate", cache_hits / len(rows))

--- a/packages/oracle/src/oracle/analytics/aggregator.py
+++ b/packages/oracle/src/oracle/analytics/aggregator.py
@@ -34,17 +34,17 @@ class SessionAggregator:
             cache_hits = 0
 
             for row in rows:
-                tool = row["tool_name"]
+                tool = str(row["tool_name"])
                 tool_counts[tool] = tool_counts.get(tool, 0) + 1
                 if row["cache_hit"]:
                     cache_hits += 1
                 if tool == "oracle_read" and row["input"]:
-                    file_paths.add(row["input"])
+                    file_paths.add(str(row["input"]))
 
             self._store.upsert_session_profile(
                 session_id=session_id,
-                started_at=float(rows[0]["ts"]),
-                ended_at=float(rows[-1]["ts"]),
+                started_at=float(str(rows[0]["ts"])),
+                ended_at=float(str(rows[-1]["ts"])),
                 tool_counts=json.dumps(tool_counts),
                 files_touched=len(file_paths),
                 cache_hit_rate=cache_hits / len(rows),

--- a/packages/oracle/src/oracle/analytics/insights.py
+++ b/packages/oracle/src/oracle/analytics/insights.py
@@ -1,0 +1,58 @@
+"""InsightsGenerator — produces actionable recommendations from analytics data."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from mcp_shared.telemetry import get_tracer
+
+from oracle.storage.store import OracleStore
+
+_tracer = get_tracer("oracle.analytics.insights")
+
+
+class InsightsGenerator:
+    """Queries accumulated analytics for actionable agent behavior insights."""
+
+    def __init__(self, store: OracleStore) -> None:
+        self._store = store
+
+    def top_file_pairs(self, limit: int = 5) -> list[dict[str, object]]:
+        """Return the most frequently co-accessed file pairs."""
+        with _tracer.start_as_current_span("insights.top_file_pairs"):
+            return self._store.get_top_coaccess_pairs(limit=limit)
+
+    def frequently_reread_files(
+        self, min_reads: int = 3, session_id: str | None = None
+    ) -> list[dict[str, object]]:
+        """Find files read >= min_reads times."""
+        with _tracer.start_as_current_span("insights.frequently_reread"):
+            return self._store.get_frequently_reread_files(
+                min_reads=min_reads, session_id=session_id
+            )
+
+    def average_cache_hit_rate(self) -> float:
+        """Compute average cache hit rate across all session profiles."""
+        with _tracer.start_as_current_span("insights.cache_hit_rate"):
+            return self._store.get_average_cache_hit_rate()
+
+    def common_tool_sequences(
+        self, window_size: int = 3, min_occurrences: int = 2
+    ) -> list[dict[str, object]]:
+        """Find repeated tool-call patterns of the given window size."""
+        with _tracer.start_as_current_span("insights.common_sequences"):
+            session_ids = self._store.get_distinct_session_ids()
+
+            pattern_counter: Counter[tuple[str, ...]] = Counter()
+            for session_id in session_ids:
+                rows = self._store.get_tool_sequences(session_id)
+                tools = [r["tool_name"] for r in rows]
+                for i in range(len(tools) - window_size + 1):
+                    pattern = tuple(tools[i : i + window_size])
+                    pattern_counter[pattern] += 1
+
+            return [
+                {"sequence": list(pattern), "count": count}
+                for pattern, count in pattern_counter.most_common()
+                if count >= min_occurrences
+            ]

--- a/packages/oracle/src/oracle/analytics/insights.py
+++ b/packages/oracle/src/oracle/analytics/insights.py
@@ -46,7 +46,7 @@ class InsightsGenerator:
             pattern_counter: Counter[tuple[str, ...]] = Counter()
             for session_id in session_ids:
                 rows = self._store.get_tool_sequences(session_id)
-                tools = [r["tool_name"] for r in rows]
+                tools = [str(r["tool_name"]) for r in rows]
                 for i in range(len(tools) - window_size + 1):
                     pattern = tuple(tools[i : i + window_size])
                     pattern_counter[pattern] += 1

--- a/packages/oracle/src/oracle/analytics/tracker.py
+++ b/packages/oracle/src/oracle/analytics/tracker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 
 from mcp_shared.telemetry import get_tracer
+
 from oracle.storage.store import OracleStore
 
 _MAX_INPUT_SUMMARY = 200

--- a/packages/oracle/src/oracle/analytics/tracker.py
+++ b/packages/oracle/src/oracle/analytics/tracker.py
@@ -1,0 +1,55 @@
+"""AnalyticsTracker — records tool sequences and file co-access patterns."""
+
+from __future__ import annotations
+
+import time
+
+from mcp_shared.telemetry import get_tracer
+from oracle.storage.store import OracleStore
+
+_MAX_INPUT_SUMMARY = 200
+_tracer = get_tracer("oracle.analytics.tracker")
+
+
+class AnalyticsTracker:
+    """Tracks tool call sequences and file co-access within a session."""
+
+    def __init__(self, store: OracleStore, session_id: str) -> None:
+        self._store = store
+        self._session_id = session_id
+        self._sequence_index = 0
+        self._files_seen: set[str] = set()
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def files_seen(self) -> frozenset[str]:
+        return frozenset(self._files_seen)
+
+    def record(self, tool_name: str, input_summary: str | None) -> None:
+        """Record a tool call — updates sequence and co-access tables."""
+        with _tracer.start_as_current_span("analytics.record") as span:
+            span.set_attribute("tool_name", tool_name)
+            truncated = input_summary[:_MAX_INPUT_SUMMARY] if input_summary else None
+            self._store.record_tool_sequence(
+                self._session_id,
+                self._sequence_index,
+                tool_name,
+                truncated,
+                time.time(),
+            )
+            self._sequence_index += 1
+
+            if tool_name == "oracle_read" and input_summary:
+                self._record_coaccess(input_summary)
+
+    def _record_coaccess(self, file_path: str) -> None:
+        """Record co-access pairs between this file and all previously seen files."""
+        if file_path in self._files_seen:
+            return
+        now = time.time()
+        for seen in self._files_seen:
+            self._store.upsert_file_coaccess(seen, file_path, now)
+        self._files_seen.add(file_path)

--- a/packages/oracle/src/oracle/cache/command_cache.py
+++ b/packages/oracle/src/oracle/cache/command_cache.py
@@ -111,6 +111,7 @@ class CommandCache:
                 text=True,
                 timeout=_COMMAND_TIMEOUT,
                 cwd=self._project_root,
+                check=False,
             )
         except subprocess.TimeoutExpired:
             return f"Command timed out after {_COMMAND_TIMEOUT}s: {command}", False, 0

--- a/packages/oracle/src/oracle/integrations/chunkhound.py
+++ b/packages/oracle/src/oracle/integrations/chunkhound.py
@@ -38,7 +38,7 @@ class ChunkhoundClient:
         except (TimeoutError, FileNotFoundError, OSError):
             return False
 
-    async def search(self, query: str, max_results: int = 5) -> list[dict[str, str]]:
+    async def search(self, _query: str, _max_results: int = 5) -> list[dict[str, str]]:
         """Semantic search. Returns empty list if not started."""
         if not self._started or self.process is None:
             return []

--- a/packages/oracle/src/oracle/integrations/chunkhound.py
+++ b/packages/oracle/src/oracle/integrations/chunkhound.py
@@ -38,7 +38,7 @@ class ChunkhoundClient:
         except (TimeoutError, FileNotFoundError, OSError):
             return False
 
-    async def search(self, _query: str, _max_results: int = 5) -> list[dict[str, str]]:
+    async def search(self, query: str, max_results: int = 5) -> list[dict[str, str]]:  # noqa: ARG002
         """Semantic search. Returns empty list if not started."""
         if not self._started or self.process is None:
             return []

--- a/packages/oracle/src/oracle/project.py
+++ b/packages/oracle/src/oracle/project.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from mcp_shared.project_detect import StackInfo, detect_project_root, detect_stack
 
 if TYPE_CHECKING:
+    from oracle.analytics.aggregator import SessionAggregator
+    from oracle.analytics.tracker import AnalyticsTracker
     from oracle.cache.command_cache import CommandCache
     from oracle.cache.file_cache import FileCache
     from oracle.cache.git_cache import GitCache
@@ -37,4 +39,6 @@ class ProjectState:
     command_cache: CommandCache | None = None
     chunkhound: ChunkhoundClient | None = None
     chunkhound_failed: bool = False
+    tracker: AnalyticsTracker | None = None
+    aggregator: SessionAggregator | None = None
     session_id: str = ""

--- a/packages/oracle/src/oracle/server.py
+++ b/packages/oracle/src/oracle/server.py
@@ -117,7 +117,7 @@ def _log(
         _tokens_saved_counter.add(tokens_saved, {"tool_name": tool_name})
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_read")
 def oracle_read(path: str) -> str:
     """Read a file, returning full content on first read or a compact delta on repeat reads."""
@@ -137,7 +137,7 @@ def oracle_read(path: str) -> str:
     return response
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_grep")
 def oracle_grep(pattern: str, path: str = ".") -> str:
     """Search source files for a regex pattern. Returns up to 50 matches."""
@@ -159,7 +159,7 @@ def oracle_grep(pattern: str, path: str = ".") -> str:
     return result
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_status")
 def oracle_status() -> str:
     """Return current project status: stack info, git branch, clean/dirty state."""
@@ -183,7 +183,7 @@ def oracle_status() -> str:
     return result
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_run")
 def oracle_run(commands: list[str]) -> str:
     """Run allowlisted commands through the cache layer. Returns cached results when unchanged."""
@@ -216,7 +216,7 @@ def oracle_run(commands: list[str]) -> str:
     return "\n\n".join(parts)
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_ask")
 def oracle_ask(question: str) -> str:
     """Ask a natural-language question about the project. Routes to cache, grep, or Haiku."""
@@ -232,7 +232,7 @@ def oracle_ask(question: str) -> str:
     return result
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_forget")
 def oracle_forget(path: str) -> str:
     """Clear the file cache for a path. Next oracle_read returns full content."""
@@ -251,7 +251,7 @@ def oracle_forget(path: str) -> str:
     return result
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_stats")
 def oracle_stats() -> str:
     """Return token savings stats for the current session and cumulative across all sessions."""
@@ -266,7 +266,7 @@ def oracle_stats() -> str:
     return handle_oracle_stats(project.session_id, project.store)
 
 
-@mcp.tool()
+@mcp.tool()  # type: ignore[misc]
 @trace_tool("oracle_insights")
 def oracle_insights() -> str:
     """Return actionable insights: file pairs, re-read candidates, cache trends."""

--- a/packages/oracle/src/oracle/server.py
+++ b/packages/oracle/src/oracle/server.py
@@ -269,7 +269,7 @@ def oracle_stats() -> str:
 @mcp.tool()
 @trace_tool("oracle_insights")
 def oracle_insights() -> str:
-    """Return actionable insights about agent behavior: file pairs, re-read candidates, cache trends."""
+    """Return actionable insights: file pairs, re-read candidates, cache trends."""
     _before_tool()
     project = _registry.current()
     if project is None:

--- a/packages/oracle/src/oracle/server.py
+++ b/packages/oracle/src/oracle/server.py
@@ -44,6 +44,8 @@ mcp = FastMCP(
 _oracle_dir = Path(os.environ.get("ORACLE_DIR", str(Path.home() / ".project-oracle")))
 _registry = ProjectRegistry(_oracle_dir)
 
+_previous_session_id: str | None = None
+
 
 def _ensure_caches(project: ProjectState) -> None:
     """Wire up cache layers if not already initialized."""
@@ -61,6 +63,14 @@ def _ensure_caches(project: ProjectState) -> None:
         from oracle.cache.command_cache import CommandCache
 
         project.command_cache = CommandCache(project.store, project.root)
+    if project.tracker is None:
+        from oracle.analytics.tracker import AnalyticsTracker
+
+        project.tracker = AnalyticsTracker(project.store, project.session_id)
+    if project.aggregator is None:
+        from oracle.analytics.aggregator import SessionAggregator
+
+        project.aggregator = SessionAggregator(project.store)
 
 
 def _before_tool() -> None:
@@ -79,11 +89,26 @@ def _log(
     tokens_saved: int,
 ) -> None:
     """Record a tool interaction to the agent log. No-op when store is not wired."""
+    global _previous_session_id
     if project.store is None:
         return
+
+    # Detect session boundary and finalize previous session
+    if (
+        _previous_session_id is not None
+        and _previous_session_id != project.session_id
+        and project.aggregator is not None
+    ):
+        project.aggregator.finalize_session(_previous_session_id)
+
+    _previous_session_id = project.session_id
+
     project.store.log_interaction(
         project.session_id, tool_name, input_data, cache_hit, tokens_saved, int(time.time())
     )
+    if project.tracker is not None:
+        project.tracker.record(tool_name, input_data)
+
     # Emit OTel metrics
     _tool_calls_counter.add(1, {"tool_name": tool_name})
     if cache_hit:
@@ -239,6 +264,21 @@ def oracle_stats() -> str:
     if project.store is None:
         return "Error: store not initialized"
     return handle_oracle_stats(project.session_id, project.store)
+
+
+@mcp.tool()
+@trace_tool("oracle_insights")
+def oracle_insights() -> str:
+    """Return actionable insights about agent behavior: file pairs, re-read candidates, cache trends."""
+    _before_tool()
+    project = _registry.current()
+    if project is None:
+        return "Error: no active project. Call oracle_read first to detect a project."
+    if project.store is None:
+        return "Error: store not initialized"
+    from oracle.tools.insights import handle_oracle_insights
+
+    return handle_oracle_insights(project.store)
 
 
 def main() -> None:

--- a/packages/oracle/src/oracle/server.py
+++ b/packages/oracle/src/oracle/server.py
@@ -8,9 +8,28 @@ import time
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
+from mcp_shared.telemetry import get_meter, get_tracer, init_telemetry, trace_tool
 
 from oracle.project import ProjectState
 from oracle.registry import ProjectRegistry
+
+# Initialize telemetry for Oracle
+init_telemetry("project-oracle")
+
+_tracer = get_tracer("oracle.server")
+_meter = get_meter("oracle.server")
+_tool_calls_counter = _meter.create_counter(
+    "oracle.tool.calls",
+    description="Number of Oracle MCP tool invocations",
+)
+_cache_hits_counter = _meter.create_counter(
+    "oracle.cache.hits",
+    description="Number of cache hits across all tools",
+)
+_tokens_saved_counter = _meter.create_counter(
+    "oracle.tokens.saved",
+    description="Total estimated tokens saved by caching",
+)
 
 mcp = FastMCP(
     "project-oracle",
@@ -46,9 +65,10 @@ def _ensure_caches(project: ProjectState) -> None:
 
 def _before_tool() -> None:
     """Drain the ingest queue and pre-populate caches before every tool call."""
-    from oracle.ingest_bridge import process_ingest
+    with _tracer.start_as_current_span("oracle.before_tool"):
+        from oracle.ingest_bridge import process_ingest
 
-    process_ingest(_registry, _oracle_dir, _ensure_caches)
+        process_ingest(_registry, _oracle_dir, _ensure_caches)
 
 
 def _log(
@@ -64,9 +84,16 @@ def _log(
     project.store.log_interaction(
         project.session_id, tool_name, input_data, cache_hit, tokens_saved, int(time.time())
     )
+    # Emit OTel metrics
+    _tool_calls_counter.add(1, {"tool_name": tool_name})
+    if cache_hit:
+        _cache_hits_counter.add(1, {"tool_name": tool_name})
+    if tokens_saved > 0:
+        _tokens_saved_counter.add(tokens_saved, {"tool_name": tool_name})
 
 
 @mcp.tool()
+@trace_tool("oracle_read")
 def oracle_read(path: str) -> str:
     """Read a file, returning full content on first read or a compact delta on repeat reads."""
     _before_tool()
@@ -86,6 +113,7 @@ def oracle_read(path: str) -> str:
 
 
 @mcp.tool()
+@trace_tool("oracle_grep")
 def oracle_grep(pattern: str, path: str = ".") -> str:
     """Search source files for a regex pattern. Returns up to 50 matches."""
     _before_tool()
@@ -107,6 +135,7 @@ def oracle_grep(pattern: str, path: str = ".") -> str:
 
 
 @mcp.tool()
+@trace_tool("oracle_status")
 def oracle_status() -> str:
     """Return current project status: stack info, git branch, clean/dirty state."""
     _before_tool()
@@ -130,6 +159,7 @@ def oracle_status() -> str:
 
 
 @mcp.tool()
+@trace_tool("oracle_run")
 def oracle_run(commands: list[str]) -> str:
     """Run allowlisted commands through the cache layer. Returns cached results when unchanged."""
     _before_tool()
@@ -162,6 +192,7 @@ def oracle_run(commands: list[str]) -> str:
 
 
 @mcp.tool()
+@trace_tool("oracle_ask")
 def oracle_ask(question: str) -> str:
     """Ask a natural-language question about the project. Routes to cache, grep, or Haiku."""
     _before_tool()
@@ -177,6 +208,7 @@ def oracle_ask(question: str) -> str:
 
 
 @mcp.tool()
+@trace_tool("oracle_forget")
 def oracle_forget(path: str) -> str:
     """Clear the file cache for a path. Next oracle_read returns full content."""
     _before_tool()
@@ -195,6 +227,7 @@ def oracle_forget(path: str) -> str:
 
 
 @mcp.tool()
+@trace_tool("oracle_stats")
 def oracle_stats() -> str:
     """Return token savings stats for the current session and cumulative across all sessions."""
     _before_tool()

--- a/packages/oracle/src/oracle/storage/store.py
+++ b/packages/oracle/src/oracle/storage/store.py
@@ -64,9 +64,39 @@ class OracleStore:
                 ts           INTEGER NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS tool_sequences (
+                id              INTEGER PRIMARY KEY,
+                session_id      TEXT NOT NULL,
+                sequence_index  INTEGER NOT NULL,
+                tool_name       TEXT NOT NULL,
+                input_summary   TEXT,
+                ts              REAL NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS file_coaccess (
+                file_a          TEXT NOT NULL,
+                file_b          TEXT NOT NULL,
+                session_count   INTEGER NOT NULL DEFAULT 1,
+                last_seen       REAL NOT NULL,
+                PRIMARY KEY (file_a, file_b)
+            );
+
+            CREATE TABLE IF NOT EXISTS session_profiles (
+                session_id      TEXT PRIMARY KEY,
+                started_at      REAL NOT NULL,
+                ended_at        REAL NOT NULL,
+                tool_counts     TEXT NOT NULL,
+                files_touched   INTEGER NOT NULL DEFAULT 0,
+                cache_hit_rate  REAL NOT NULL DEFAULT 0.0
+            );
+
             CREATE INDEX IF NOT EXISTS idx_file_cache_last_read ON file_cache(last_read);
             CREATE INDEX IF NOT EXISTS idx_agent_log_session ON agent_log(session_id);
             CREATE INDEX IF NOT EXISTS idx_command_results_ran ON command_results(ran_at);
+            CREATE INDEX IF NOT EXISTS idx_tool_seq_session
+                ON tool_sequences(session_id);
+            CREATE INDEX IF NOT EXISTS idx_coaccess_count
+                ON file_coaccess(session_count DESC);
             """
         )
 

--- a/packages/oracle/src/oracle/storage/store.py
+++ b/packages/oracle/src/oracle/storage/store.py
@@ -244,6 +244,136 @@ class OracleStore:
         row = self._conn.execute("SELECT COUNT(*) AS cnt FROM agent_log").fetchone()
         return row["cnt"] if row is not None else 0
 
+    def record_tool_sequence(
+        self,
+        session_id: str,
+        sequence_index: int,
+        tool_name: str,
+        input_summary: str | None,
+        timestamp: float,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO tool_sequences (session_id, sequence_index, tool_name, input_summary, ts)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (session_id, sequence_index, tool_name, input_summary, timestamp),
+        )
+        self._conn.commit()
+
+    def get_tool_sequences(self, session_id: str) -> list[dict[str, object]]:
+        rows = self._conn.execute(
+            "SELECT * FROM tool_sequences WHERE session_id = ? ORDER BY sequence_index",
+            (session_id,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def upsert_file_coaccess(self, file_a: str, file_b: str, timestamp: float) -> None:
+        a, b = (file_a, file_b) if file_a < file_b else (file_b, file_a)
+        self._conn.execute(
+            """
+            INSERT INTO file_coaccess (file_a, file_b, session_count, last_seen)
+            VALUES (?, ?, 1, ?)
+            ON CONFLICT(file_a, file_b) DO UPDATE SET
+                session_count = session_count + 1,
+                last_seen = excluded.last_seen
+            """,
+            (a, b, timestamp),
+        )
+        self._conn.commit()
+
+    def get_top_coaccess_pairs(self, limit: int = 20) -> list[dict[str, object]]:
+        rows = self._conn.execute(
+            "SELECT * FROM file_coaccess ORDER BY session_count DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_coaccess_for_file(self, file_path: str) -> list[dict[str, object]]:
+        rows = self._conn.execute(
+            "SELECT * FROM file_coaccess "
+            "WHERE file_a = ? OR file_b = ? "
+            "ORDER BY session_count DESC",
+            (file_path, file_path),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def upsert_session_profile(
+        self,
+        session_id: str,
+        started_at: float,
+        ended_at: float,
+        tool_counts: str,
+        files_touched: int,
+        cache_hit_rate: float,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO session_profiles
+                (session_id, started_at, ended_at, tool_counts, files_touched, cache_hit_rate)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                ended_at = excluded.ended_at,
+                tool_counts = excluded.tool_counts,
+                files_touched = excluded.files_touched,
+                cache_hit_rate = excluded.cache_hit_rate
+            """,
+            (session_id, started_at, ended_at, tool_counts, files_touched, cache_hit_rate),
+        )
+        self._conn.commit()
+
+    def get_session_profile(self, session_id: str) -> dict[str, object] | None:
+        row = self._conn.execute(
+            "SELECT * FROM session_profiles WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    def get_recent_session_profiles(self, limit: int = 20) -> list[dict[str, object]]:
+        rows = self._conn.execute(
+            "SELECT * FROM session_profiles ORDER BY ended_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_session_log(self, session_id: str) -> list[dict[str, object]]:
+        rows = self._conn.execute(
+            "SELECT tool_name, input, cache_hit, ts FROM agent_log "
+            "WHERE session_id = ? ORDER BY ts",
+            (session_id,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_distinct_session_ids(self) -> list[str]:
+        rows = self._conn.execute("SELECT DISTINCT session_id FROM tool_sequences").fetchall()
+        return [row[0] for row in rows]
+
+    def get_frequently_reread_files(
+        self, min_reads: int = 3, session_id: str | None = None
+    ) -> list[dict[str, object]]:
+        where = "WHERE tool_name = 'oracle_read' AND input IS NOT NULL"
+        params: list[object] = []
+        if session_id:
+            where += " AND session_id = ?"
+            params.append(session_id)
+        rows = self._conn.execute(
+            f"SELECT input AS path, COUNT(*) AS read_count "
+            f"FROM agent_log {where} "
+            f"GROUP BY input HAVING read_count >= ? "
+            f"ORDER BY read_count DESC",
+            [*params, min_reads],
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_average_cache_hit_rate(self) -> float:
+        row = self._conn.execute(
+            "SELECT AVG(cache_hit_rate) AS avg_rate FROM session_profiles"
+        ).fetchone()
+        if row is None or row["avg_rate"] is None:
+            return 0.0
+        return float(row["avg_rate"])
+
     def evict_stale_files(self, max_age_days: int = 30, now: int | None = None) -> int:
         if now is None:
             now = int(time.time())

--- a/packages/oracle/src/oracle/tools/ask.py
+++ b/packages/oracle/src/oracle/tools/ask.py
@@ -172,6 +172,7 @@ def _fallback_grep(question: str, root: Path) -> str:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                check=False,
             )
         except (subprocess.TimeoutExpired, OSError):
             continue

--- a/packages/oracle/src/oracle/tools/grep.py
+++ b/packages/oracle/src/oracle/tools/grep.py
@@ -26,6 +26,7 @@ def handle_oracle_grep(pattern: str, path: str) -> str:
             capture_output=True,
             text=True,
             timeout=_GREP_TIMEOUT,
+            check=False,
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
         return f"Error: grep failed for pattern '{pattern}': {exc}"

--- a/packages/oracle/src/oracle/tools/insights.py
+++ b/packages/oracle/src/oracle/tools/insights.py
@@ -15,8 +15,9 @@ def handle_oracle_insights(store: OracleStore) -> str:
     pairs = gen.top_file_pairs(limit=5)
     if pairs:
         lines = ["File pairs (always read together):"]
-        for p in pairs:
-            lines.append(f"  {p['file_a']} ↔ {p['file_b']}  ({p['session_count']} sessions)")
+        lines.extend(
+            f"  {p['file_a']} ↔ {p['file_b']}  ({p['session_count']} sessions)" for p in pairs
+        )
         sections.append("\n".join(lines))
 
     rereads = gen.frequently_reread_files(min_reads=3)

--- a/packages/oracle/src/oracle/tools/insights.py
+++ b/packages/oracle/src/oracle/tools/insights.py
@@ -1,0 +1,44 @@
+"""Tool handler for oracle_insights — actionable agent behavior analytics."""
+
+from __future__ import annotations
+
+from oracle.analytics.insights import InsightsGenerator
+from oracle.storage.store import OracleStore
+
+
+def handle_oracle_insights(store: OracleStore) -> str:
+    """Return formatted analytics insights."""
+    gen = InsightsGenerator(store)
+
+    sections: list[str] = []
+
+    pairs = gen.top_file_pairs(limit=5)
+    if pairs:
+        lines = ["File pairs (always read together):"]
+        for p in pairs:
+            lines.append(f"  {p['file_a']} ↔ {p['file_b']}  ({p['session_count']} sessions)")
+        sections.append("\n".join(lines))
+
+    rereads = gen.frequently_reread_files(min_reads=3)
+    if rereads:
+        lines = ["Frequently re-read files (consider pinning):"]
+        for r in rereads:
+            lines.append(f"  {r['path']}  ({r['read_count']} reads)")
+        sections.append("\n".join(lines))
+
+    rate = gen.average_cache_hit_rate()
+    if rate > 0:
+        sections.append(f"Cache hit rate: {rate:.0%} (average across sessions)")
+
+    sequences = gen.common_tool_sequences(window_size=3, min_occurrences=2)
+    if sequences:
+        lines = ["Common tool patterns:"]
+        for s in sequences[:5]:
+            arrow = " → ".join(s["sequence"])
+            lines.append(f"  {arrow}  ({s['count']}x)")
+        sections.append("\n".join(lines))
+
+    if not sections:
+        return "No analytics data yet. Use Oracle tools for a few sessions to build up patterns."
+
+    return "\n\n".join(sections)

--- a/packages/oracle/src/oracle/tools/insights.py
+++ b/packages/oracle/src/oracle/tools/insights.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from oracle.analytics.insights import InsightsGenerator
 from oracle.storage.store import OracleStore
 
@@ -35,7 +37,8 @@ def handle_oracle_insights(store: OracleStore) -> str:
     if sequences:
         lines = ["Common tool patterns:"]
         for s in sequences[:5]:
-            arrow = " → ".join(s["sequence"])
+            seq = cast("list[str]", s["sequence"])
+            arrow = " → ".join(seq)
             lines.append(f"  {arrow}  ({s['count']}x)")
         sections.append("\n".join(lines))
 

--- a/packages/oracle/src/oracle/tools/status.py
+++ b/packages/oracle/src/oracle/tools/status.py
@@ -7,7 +7,7 @@ from oracle.project import StackInfo
 from oracle.storage.store import OracleStore
 
 
-def handle_oracle_status(stack: StackInfo, git_cache: GitCache, store: OracleStore) -> str:
+def handle_oracle_status(stack: StackInfo, git_cache: GitCache, _store: OracleStore) -> str:
     """Return formatted project status: stack, git state, clean/dirty."""
     snapshot = git_cache.refresh()
 

--- a/packages/oracle/src/oracle/watcher.py
+++ b/packages/oracle/src/oracle/watcher.py
@@ -36,7 +36,7 @@ class OracleWatcher:
         self._stop_event.set()
 
 
-def _source_filter(change: Change, path: str) -> bool:
+def _source_filter(_change: Change, path: str) -> bool:
     """Return True for source files, False for ignored directories."""
     skip_dirs = {".git", ".venv", "node_modules", "__pycache__", ".mypy_cache"}
     return not any(part in skip_dirs for part in Path(path).parts)

--- a/packages/oracle/tests/conftest.py
+++ b/packages/oracle/tests/conftest.py
@@ -8,6 +8,12 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent OTel from connecting to SigNoz during tests."""
+    monkeypatch.setenv("ORACLE_TELEMETRY_ENABLED", "false")
+
+
 @pytest.fixture
 def tmp_project(tmp_path: Path) -> Path:
     """Create a temp project directory with a fake .git marker for project root detection.

--- a/packages/oracle/tests/test_analytics_aggregator.py
+++ b/packages/oracle/tests/test_analytics_aggregator.py
@@ -7,7 +7,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.analytics.aggregator import SessionAggregator
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_analytics_aggregator.py
+++ b/packages/oracle/tests/test_analytics_aggregator.py
@@ -1,0 +1,69 @@
+"""Tests for SessionAggregator."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from oracle.analytics.aggregator import SessionAggregator
+from oracle.storage.store import OracleStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[OracleStore, None, None]:
+    s = OracleStore(tmp_path / "oracle.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def aggregator(store: OracleStore) -> SessionAggregator:
+    return SessionAggregator(store)
+
+
+@pytest.mark.medium
+class DescribeSessionAggregation:
+    def it_computes_profile_from_agent_log(
+        self, aggregator: SessionAggregator, store: OracleStore
+    ) -> None:
+        store.log_interaction("sess-1", "oracle_read", "a.py", True, 500, 1000)
+        store.log_interaction("sess-1", "oracle_read", "b.py", False, 0, 1001)
+        store.log_interaction("sess-1", "oracle_run", "pytest", True, 200, 1002)
+        aggregator.finalize_session("sess-1")
+        profile = store.get_session_profile("sess-1")
+        assert profile is not None
+        tool_counts = json.loads(profile["tool_counts"])
+        assert tool_counts == {"oracle_read": 2, "oracle_run": 1}
+        assert profile["files_touched"] == 2
+        assert profile["cache_hit_rate"] == pytest.approx(2 / 3)
+
+    def it_handles_session_with_no_cache_hits(
+        self, aggregator: SessionAggregator, store: OracleStore
+    ) -> None:
+        store.log_interaction("sess-2", "oracle_read", "a.py", False, 0, 1000)
+        store.log_interaction("sess-2", "oracle_read", "b.py", False, 0, 1001)
+        aggregator.finalize_session("sess-2")
+        profile = store.get_session_profile("sess-2")
+        assert profile is not None
+        assert profile["cache_hit_rate"] == pytest.approx(0.0)
+
+    def it_handles_empty_session(
+        self, aggregator: SessionAggregator, store: OracleStore
+    ) -> None:
+        aggregator.finalize_session("nonexistent")
+        profile = store.get_session_profile("nonexistent")
+        assert profile is None
+
+    def it_counts_unique_file_paths(
+        self, aggregator: SessionAggregator, store: OracleStore
+    ) -> None:
+        store.log_interaction("sess-3", "oracle_read", "a.py", True, 100, 1000)
+        store.log_interaction("sess-3", "oracle_read", "a.py", True, 100, 1001)
+        store.log_interaction("sess-3", "oracle_read", "b.py", False, 0, 1002)
+        aggregator.finalize_session("sess-3")
+        profile = store.get_session_profile("sess-3")
+        assert profile is not None
+        assert profile["files_touched"] == 2

--- a/packages/oracle/tests/test_analytics_aggregator.py
+++ b/packages/oracle/tests/test_analytics_aggregator.py
@@ -50,9 +50,7 @@ class DescribeSessionAggregation:
         assert profile is not None
         assert profile["cache_hit_rate"] == pytest.approx(0.0)
 
-    def it_handles_empty_session(
-        self, aggregator: SessionAggregator, store: OracleStore
-    ) -> None:
+    def it_handles_empty_session(self, aggregator: SessionAggregator, store: OracleStore) -> None:
         aggregator.finalize_session("nonexistent")
         profile = store.get_session_profile("nonexistent")
         assert profile is None

--- a/packages/oracle/tests/test_analytics_insights.py
+++ b/packages/oracle/tests/test_analytics_insights.py
@@ -1,0 +1,84 @@
+"""Tests for InsightsGenerator."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from oracle.analytics.insights import InsightsGenerator
+from oracle.storage.store import OracleStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[OracleStore, None, None]:
+    s = OracleStore(tmp_path / "oracle.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def insights(store: OracleStore) -> InsightsGenerator:
+    return InsightsGenerator(store)
+
+
+@pytest.mark.medium
+class DescribeFilePairInsights:
+    def it_returns_top_file_pairs(self, insights: InsightsGenerator, store: OracleStore) -> None:
+        store.upsert_file_coaccess("server.py", "test_server.py", 1000.0)
+        store.upsert_file_coaccess("server.py", "test_server.py", 2000.0)
+        store.upsert_file_coaccess("models.py", "test_models.py", 1000.0)
+        result = insights.top_file_pairs(limit=5)
+        assert len(result) == 2
+        assert result[0]["file_a"] == "server.py"
+        assert result[0]["session_count"] == 2
+
+    def it_returns_empty_list_when_no_data(self, insights: InsightsGenerator) -> None:
+        assert insights.top_file_pairs(limit=5) == []
+
+
+@pytest.mark.medium
+class DescribeFrequentRereadInsights:
+    def it_identifies_files_read_multiple_times(
+        self, insights: InsightsGenerator, store: OracleStore
+    ) -> None:
+        store.log_interaction("s1", "oracle_read", "config.py", True, 100, 1000)
+        store.log_interaction("s1", "oracle_read", "config.py", True, 100, 1001)
+        store.log_interaction("s1", "oracle_read", "config.py", True, 100, 1002)
+        store.log_interaction("s1", "oracle_read", "other.py", False, 0, 1003)
+        result = insights.frequently_reread_files(min_reads=3)
+        assert len(result) == 1
+        assert result[0]["path"] == "config.py"
+        assert result[0]["read_count"] == 3
+
+
+@pytest.mark.medium
+class DescribeCacheHitTrend:
+    def it_computes_average_cache_hit_rate(
+        self, insights: InsightsGenerator, store: OracleStore
+    ) -> None:
+        store.upsert_session_profile("s1", 100.0, 200.0, "{}", 3, 0.6)
+        store.upsert_session_profile("s2", 300.0, 400.0, "{}", 5, 0.8)
+        rate = insights.average_cache_hit_rate()
+        assert rate == pytest.approx(0.7)
+
+    def it_returns_zero_when_no_sessions(self, insights: InsightsGenerator) -> None:
+        assert insights.average_cache_hit_rate() == pytest.approx(0.0)
+
+
+@pytest.mark.medium
+class DescribeCommonSequences:
+    def it_finds_repeated_tool_patterns(
+        self, insights: InsightsGenerator, store: OracleStore
+    ) -> None:
+        store.record_tool_sequence("s1", 0, "oracle_read", "a.py", 1000.0)
+        store.record_tool_sequence("s1", 1, "oracle_run", "pytest", 1001.0)
+        store.record_tool_sequence("s1", 2, "oracle_read", "b.py", 1002.0)
+        store.record_tool_sequence("s2", 0, "oracle_read", "a.py", 2000.0)
+        store.record_tool_sequence("s2", 1, "oracle_run", "pytest", 2001.0)
+        store.record_tool_sequence("s2", 2, "oracle_read", "b.py", 2002.0)
+        result = insights.common_tool_sequences(window_size=3, min_occurrences=2)
+        assert len(result) >= 1
+        assert result[0]["sequence"] == ["oracle_read", "oracle_run", "oracle_read"]
+        assert result[0]["count"] == 2

--- a/packages/oracle/tests/test_analytics_insights.py
+++ b/packages/oracle/tests/test_analytics_insights.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.analytics.insights import InsightsGenerator
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_analytics_tracker.py
+++ b/packages/oracle/tests/test_analytics_tracker.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.analytics.tracker import AnalyticsTracker
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_analytics_tracker.py
+++ b/packages/oracle/tests/test_analytics_tracker.py
@@ -1,0 +1,99 @@
+"""Tests for AnalyticsTracker."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from oracle.analytics.tracker import AnalyticsTracker
+from oracle.storage.store import OracleStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[OracleStore, None, None]:
+    s = OracleStore(tmp_path / "oracle.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def tracker(store: OracleStore) -> AnalyticsTracker:
+    return AnalyticsTracker(store, session_id="test-sess")
+
+
+@pytest.mark.medium
+class DescribeSequenceTracking:
+    def it_records_first_tool_call_at_index_zero(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "/src/main.py")
+        rows = store.get_tool_sequences("test-sess")
+        assert len(rows) == 1
+        assert rows[0]["sequence_index"] == 0
+        assert rows[0]["tool_name"] == "oracle_read"
+
+    def it_increments_sequence_index(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "a.py")
+        tracker.record("oracle_run", "pytest")
+        tracker.record("oracle_read", "b.py")
+        rows = store.get_tool_sequences("test-sess")
+        assert [r["sequence_index"] for r in rows] == [0, 1, 2]
+
+    def it_truncates_long_input_summary(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        long_path = "/very/long/path/" + "x" * 300
+        tracker.record("oracle_read", long_path)
+        rows = store.get_tool_sequences("test-sess")
+        assert len(rows[0]["input_summary"]) <= 200
+
+
+@pytest.mark.medium
+class DescribeCoaccessTracking:
+    def it_records_no_pairs_on_first_read(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "a.py")
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 0
+
+    def it_records_one_pair_on_second_read(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "a.py")
+        tracker.record("oracle_read", "b.py")
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 1
+        assert pairs[0]["file_a"] == "a.py"
+        assert pairs[0]["file_b"] == "b.py"
+
+    def it_records_three_pairs_on_third_read(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "a.py")
+        tracker.record("oracle_read", "b.py")
+        tracker.record("oracle_read", "c.py")
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 3
+
+    def it_ignores_non_read_tools(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "a.py")
+        tracker.record("oracle_run", "pytest")
+        tracker.record("oracle_read", "b.py")
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 1
+
+    def it_does_not_duplicate_file_in_seen_set(
+        self, tracker: AnalyticsTracker, store: OracleStore
+    ) -> None:
+        tracker.record("oracle_read", "a.py")
+        tracker.record("oracle_read", "a.py")
+        tracker.record("oracle_read", "b.py")
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 1

--- a/packages/oracle/tests/test_analytics_tracker.py
+++ b/packages/oracle/tests/test_analytics_tracker.py
@@ -34,9 +34,7 @@ class DescribeSequenceTracking:
         assert rows[0]["sequence_index"] == 0
         assert rows[0]["tool_name"] == "oracle_read"
 
-    def it_increments_sequence_index(
-        self, tracker: AnalyticsTracker, store: OracleStore
-    ) -> None:
+    def it_increments_sequence_index(self, tracker: AnalyticsTracker, store: OracleStore) -> None:
         tracker.record("oracle_read", "a.py")
         tracker.record("oracle_run", "pytest")
         tracker.record("oracle_read", "b.py")
@@ -80,9 +78,7 @@ class DescribeCoaccessTracking:
         pairs = store.get_top_coaccess_pairs(limit=10)
         assert len(pairs) == 3
 
-    def it_ignores_non_read_tools(
-        self, tracker: AnalyticsTracker, store: OracleStore
-    ) -> None:
+    def it_ignores_non_read_tools(self, tracker: AnalyticsTracker, store: OracleStore) -> None:
         tracker.record("oracle_read", "a.py")
         tracker.record("oracle_run", "pytest")
         tracker.record("oracle_read", "b.py")

--- a/packages/oracle/tests/test_ask.py
+++ b/packages/oracle/tests/test_ask.py
@@ -7,14 +7,13 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.cache.command_cache import CommandCache
 from oracle.cache.file_cache import FileCache
 from oracle.cache.git_cache import GitCache
 from oracle.integrations.chunkhound import ChunkhoundClient
 from oracle.project import ProjectState, StackInfo
 from oracle.storage.store import OracleStore
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/packages/oracle/tests/test_benchmark.py
+++ b/packages/oracle/tests/test_benchmark.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_bug_hunt.py
+++ b/packages/oracle/tests/test_bug_hunt.py
@@ -6,9 +6,8 @@ import json
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.storage.store import OracleStore
+from pytest_mock import MockerFixture
 
 
 @pytest.mark.medium

--- a/packages/oracle/tests/test_bug_hunt_r2.py
+++ b/packages/oracle/tests/test_bug_hunt_r2.py
@@ -6,11 +6,10 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.cache.command_cache import CommandCache
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/packages/oracle/tests/test_bug_hunt_r3.py
+++ b/packages/oracle/tests/test_bug_hunt_r3.py
@@ -6,10 +6,9 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/packages/oracle/tests/test_characterization.py
+++ b/packages/oracle/tests/test_characterization.py
@@ -6,7 +6,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
 from oracle.tools.forget import handle_oracle_forget

--- a/packages/oracle/tests/test_chunkhound.py
+++ b/packages/oracle/tests/test_chunkhound.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.integrations.chunkhound import ChunkhoundClient
+from pytest_mock import MockerFixture
 
 
 class DescribeChunkhoundClient:

--- a/packages/oracle/tests/test_command_cache.py
+++ b/packages/oracle/tests/test_command_cache.py
@@ -8,8 +8,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.cache.command_cache import (
     DEFAULT_ALLOWLIST,
     CommandCache,
@@ -17,6 +15,7 @@ from oracle.cache.command_cache import (
 )
 from oracle.formatting import format_elapsed
 from oracle.storage.store import OracleStore
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture
@@ -46,7 +45,7 @@ def cache(store: OracleStore, project: Path) -> CommandCache:
 @pytest.mark.small
 class DescribeFormatElapsed:
     @pytest.mark.parametrize(
-        "seconds,expected",
+        ("seconds", "expected"),
         [
             (5, "5s"),
             (59, "59s"),

--- a/packages/oracle/tests/test_concurrent.py
+++ b/packages/oracle/tests/test_concurrent.py
@@ -7,7 +7,6 @@ import threading
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.ingest import drain_ingest_queue
 from oracle.storage.store import OracleStore

--- a/packages/oracle/tests/test_contract.py
+++ b/packages/oracle/tests/test_contract.py
@@ -7,11 +7,11 @@ import pytest
 
 @pytest.mark.small
 class DescribeMCPContract:
-    async def it_exposes_exactly_seven_tools(self) -> None:
+    async def it_exposes_exactly_eight_tools(self) -> None:
         from oracle.server import mcp
 
         tools = await mcp.list_tools()
-        assert len(tools) == 7
+        assert len(tools) == 8
 
     async def it_exposes_all_required_tool_names(self) -> None:
         from oracle.server import mcp
@@ -26,6 +26,7 @@ class DescribeMCPContract:
             "oracle_ask",
             "oracle_forget",
             "oracle_stats",
+            "oracle_insights",
         }
         assert required <= tool_names
 
@@ -79,5 +80,13 @@ class DescribeMCPContract:
 
         tools = {t.name: t for t in await mcp.list_tools()}
         schema = tools["oracle_status"].inputSchema
+        required = schema.get("required", [])
+        assert len(required) == 0
+
+    async def it_oracle_insights_has_no_required_parameters(self) -> None:
+        from oracle.server import mcp
+
+        tools = {t.name: t for t in await mcp.list_tools()}
+        schema = tools["oracle_insights"].inputSchema
         required = schema.get("required", [])
         assert len(required) == 0

--- a/packages/oracle/tests/test_file_cache.py
+++ b/packages/oracle/tests/test_file_cache.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
 
@@ -26,7 +25,7 @@ def cache(store: OracleStore) -> FileCache:
 
 class DescribeFormatElapsed:
     @pytest.mark.parametrize(
-        "seconds,expected",
+        ("seconds", "expected"),
         [
             (30, "30s"),
             (90, "1m"),
@@ -194,7 +193,7 @@ class DescribeFileCacheSizeLimit:
         # Write exactly _MAX_FILE_SIZE bytes (should be accepted)
         f.write_bytes(b"x" * _MAX_FILE_SIZE)
 
-        result, tokens_saved = cache.smart_read_with_stats(str(f))
+        result, _tokens_saved = cache.smart_read_with_stats(str(f))
         assert "file too large" not in result.lower()
 
 

--- a/packages/oracle/tests/test_file_cache_properties.py
+++ b/packages/oracle/tests/test_file_cache_properties.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
 from oracle.cache.file_cache import FileCache, _compute_delta
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_forget.py
+++ b/packages/oracle/tests/test_forget.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
 from oracle.tools.forget import handle_oracle_forget

--- a/packages/oracle/tests/test_git_cache.py
+++ b/packages/oracle/tests/test_git_cache.py
@@ -6,7 +6,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.git_cache import GitCache, GitSnapshot
 from oracle.integrations.git import (
     get_branch,

--- a/packages/oracle/tests/test_grep.py
+++ b/packages/oracle/tests/test_grep.py
@@ -6,9 +6,8 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.tools.grep import handle_oracle_grep
+from pytest_mock import MockerFixture
 
 
 @pytest.mark.medium

--- a/packages/oracle/tests/test_ingest.py
+++ b/packages/oracle/tests/test_ingest.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from pytest_mock import MockerFixture
-
 from oracle.ingest import drain_ingest_queue
+from pytest_mock import MockerFixture
 
 
 class DescribeIngestQueue:

--- a/packages/oracle/tests/test_ingest_bridge.py
+++ b/packages/oracle/tests/test_ingest_bridge.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from oracle.ingest_bridge import process_ingest
 from oracle.project import ProjectState
 
@@ -30,7 +29,7 @@ class DescribeProcessIngest:
         (project / "hello.py").write_text("print('hello world')\n")
         return project
 
-    def _enqueue(self, oracle_dir: Path, entry: dict) -> None:  # noqa: ANN001
+    def _enqueue(self, oracle_dir: Path, entry: dict) -> None:
         """Write an entry into the ingest queue directory."""
         queue_dir = oracle_dir / "ingest"
         queue_dir.mkdir(exist_ok=True)

--- a/packages/oracle/tests/test_ingest_fuzz.py
+++ b/packages/oracle/tests/test_ingest_fuzz.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
 from oracle.ingest import drain_ingest_queue
 
 

--- a/packages/oracle/tests/test_insights_tool.py
+++ b/packages/oracle/tests/test_insights_tool.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.storage.store import OracleStore
 from oracle.tools.insights import handle_oracle_insights
 

--- a/packages/oracle/tests/test_insights_tool.py
+++ b/packages/oracle/tests/test_insights_tool.py
@@ -1,0 +1,39 @@
+"""Tests for oracle_insights tool handler."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from oracle.storage.store import OracleStore
+from oracle.tools.insights import handle_oracle_insights
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[OracleStore, None, None]:
+    s = OracleStore(tmp_path / "oracle.db")
+    yield s
+    s.close()
+
+
+@pytest.mark.medium
+class DescribeOracleInsightsTool:
+    def it_returns_formatted_insights(self, store: OracleStore) -> None:
+        store.upsert_file_coaccess("server.py", "test_server.py", 1000.0)
+        store.upsert_file_coaccess("server.py", "test_server.py", 2000.0)
+        store.log_interaction("s1", "oracle_read", "config.py", True, 100, 1000)
+        store.log_interaction("s1", "oracle_read", "config.py", True, 100, 1001)
+        store.log_interaction("s1", "oracle_read", "config.py", True, 100, 1002)
+        store.upsert_session_profile("s1", 1000.0, 1002.0, "{}", 1, 0.8)
+        result = handle_oracle_insights(store)
+        assert "File pairs" in result
+        assert "server.py" in result
+        assert "test_server.py" in result
+        assert "config.py" in result
+        assert "Cache hit rate" in result
+
+    def it_handles_empty_data(self, store: OracleStore) -> None:
+        result = handle_oracle_insights(store)
+        assert "No analytics data" in result

--- a/packages/oracle/tests/test_integration.py
+++ b/packages/oracle/tests/test_integration.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.ingest_bridge import process_ingest
 from oracle.project import ProjectState
@@ -54,11 +53,11 @@ class DescribeLoggingPipeline:
         file_path = str(target)
 
         # First read: cache miss, tokens_saved == 0
-        response1, tokens_saved1 = project.file_cache.smart_read_with_stats(file_path)
+        _response1, tokens_saved1 = project.file_cache.smart_read_with_stats(file_path)
         assert tokens_saved1 == 0
 
         # Second read: cache hit, tokens_saved > 0 (file unchanged)
-        response2, tokens_saved2 = project.file_cache.smart_read_with_stats(file_path)
+        _response2, tokens_saved2 = project.file_cache.smart_read_with_stats(file_path)
         assert tokens_saved2 > 0
 
         # Log both interactions
@@ -131,7 +130,7 @@ class DescribeIngestPipeline:
             project.file_cache = FileCache(project.store)
 
     @staticmethod
-    def _enqueue(oracle_dir: Path, entry: dict) -> None:  # noqa: ANN001
+    def _enqueue(oracle_dir: Path, entry: dict) -> None:
         """Write an entry into the ingest queue directory."""
         queue_dir = oracle_dir / "ingest"
         queue_dir.mkdir(exist_ok=True)
@@ -225,7 +224,7 @@ class DescribeCrossSessionCacheBehavior:
 
         # Session A: populate the cache
         cache_a = FileCache(store)
-        response_a, tokens_saved_a = cache_a.smart_read_with_stats(file_path)
+        _response_a, tokens_saved_a = cache_a.smart_read_with_stats(file_path)
         assert tokens_saved_a == 0  # first read is always a miss
 
         # Session B: new FileCache (fresh Python object), same OracleStore

--- a/packages/oracle/tests/test_intent.py
+++ b/packages/oracle/tests/test_intent.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import pytest
-
 from oracle.intent import Intent, classify_intent
 
 
 class DescribeClassifyIntent:
     @pytest.mark.parametrize(
-        "question,expected",
+        ("question", "expected"),
         [
             ("what changed?", Intent.GIT_STATUS),
             ("any modified files?", Intent.GIT_STATUS),
@@ -22,7 +21,7 @@ class DescribeClassifyIntent:
         assert classify_intent(question) == expected
 
     @pytest.mark.parametrize(
-        "question,expected",
+        ("question", "expected"),
         [
             ("ready to push?", Intent.READINESS),
             ("can I merge this?", Intent.READINESS),
@@ -34,7 +33,7 @@ class DescribeClassifyIntent:
         assert classify_intent(question) == expected
 
     @pytest.mark.parametrize(
-        "question,expected",
+        ("question", "expected"),
         [
             ("are tests passing?", Intent.TEST_STATUS),
             ("what's failing?", Intent.TEST_STATUS),
@@ -47,7 +46,7 @@ class DescribeClassifyIntent:
         assert classify_intent(question) == expected
 
     @pytest.mark.parametrize(
-        "question,expected",
+        ("question", "expected"),
         [
             ("what's the project structure?", Intent.PROJECT_STRUCTURE),
             ("what stack is this?", Intent.PROJECT_STRUCTURE),

--- a/packages/oracle/tests/test_read.py
+++ b/packages/oracle/tests/test_read.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.file_cache import FileCache
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_run.py
+++ b/packages/oracle/tests/test_run.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.command_cache import CommandCache, CommandNotAllowedError
 from oracle.storage.store import OracleStore
 

--- a/packages/oracle/tests/test_server.py
+++ b/packages/oracle/tests/test_server.py
@@ -824,9 +824,7 @@ class DescribeOracleForgetFileCacheNone:
 class DescribeOTelInstrumentation:
     """Verify OTel decorators and metrics do not break tool behavior."""
 
-    def it_preserves_oracle_read_behavior(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def it_preserves_oracle_read_behavior(self, tmp_path: Path, mocker: MockerFixture) -> None:
         from oracle.registry import ProjectRegistry
         from oracle.server import oracle_read
 
@@ -842,9 +840,7 @@ class DescribeOTelInstrumentation:
         result = oracle_read(str(project_dir / "foo.py"))
         assert "x = 1" in result
 
-    def it_records_tool_calls_metric_on_read(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def it_records_tool_calls_metric_on_read(self, tmp_path: Path, mocker: MockerFixture) -> None:
         from oracle.registry import ProjectRegistry
         from oracle.server import _tool_calls_counter, oracle_read
 
@@ -861,9 +857,7 @@ class DescribeOTelInstrumentation:
         oracle_read(str(project_dir / "foo.py"))
         mock_add.assert_called()
 
-    def it_records_cache_hits_metric_on_reread(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def it_records_cache_hits_metric_on_reread(self, tmp_path: Path, mocker: MockerFixture) -> None:
         from oracle.registry import ProjectRegistry
         from oracle.server import _cache_hits_counter, oracle_read
 
@@ -942,9 +936,7 @@ class DescribeOracleInsightsTool:
         result = oracle_insights()
         assert "no active project" in result.lower()
 
-    def it_returns_insights_for_active_project(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def it_returns_insights_for_active_project(self, tmp_path: Path, mocker: MockerFixture) -> None:
         from oracle.registry import ProjectRegistry
         from oracle.server import oracle_insights, oracle_read
 
@@ -960,9 +952,7 @@ class DescribeOracleInsightsTool:
         result = oracle_insights()
         assert "no analytics data" in result.lower()
 
-    def it_returns_error_when_store_is_none(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def it_returns_error_when_store_is_none(self, tmp_path: Path, mocker: MockerFixture) -> None:
         from oracle.registry import ProjectRegistry
         from oracle.server import oracle_insights
 

--- a/packages/oracle/tests/test_server.py
+++ b/packages/oracle/tests/test_server.py
@@ -775,6 +775,111 @@ class DescribeOracleForgetFileCacheNone:
         assert "file cache not initialized" in result.lower()
 
 
+class DescribeOTelInstrumentation:
+    """Verify OTel decorators and metrics do not break tool behavior."""
+
+    def it_preserves_oracle_read_behavior(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_read
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / ".git").mkdir()
+        (project_dir / "foo.py").write_text("x = 1\n")
+
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        result = oracle_read(str(project_dir / "foo.py"))
+        assert "x = 1" in result
+
+    def it_records_tool_calls_metric_on_read(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import _tool_calls_counter, oracle_read
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / ".git").mkdir()
+        (project_dir / "foo.py").write_text("x = 1\n")
+
+        mock_add = mocker.patch.object(_tool_calls_counter, "add")
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        oracle_read(str(project_dir / "foo.py"))
+        mock_add.assert_called()
+
+    def it_records_cache_hits_metric_on_reread(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import _cache_hits_counter, oracle_read
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / ".git").mkdir()
+        (project_dir / "foo.py").write_text("x = 1\n")
+
+        mock_add = mocker.patch.object(_cache_hits_counter, "add")
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        # First read: miss. Second read: cache hit.
+        oracle_read(str(project_dir / "foo.py"))
+        oracle_read(str(project_dir / "foo.py"))
+        mock_add.assert_called()
+
+    def it_records_tokens_saved_metric_on_reread(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import _tokens_saved_counter, oracle_read
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / ".git").mkdir()
+        (project_dir / "foo.py").write_text("x = 1\n")
+
+        mock_add = mocker.patch.object(_tokens_saved_counter, "add")
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        # First read: miss. Second read: tokens saved > 0.
+        oracle_read(str(project_dir / "foo.py"))
+        oracle_read(str(project_dir / "foo.py"))
+        mock_add.assert_called()
+        # The amount argument is the first positional arg
+        amount = mock_add.call_args[0][0]
+        assert amount > 0
+
+    def it_does_not_record_cache_hit_on_first_read(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import _cache_hits_counter, oracle_read
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / ".git").mkdir()
+        (project_dir / "foo.py").write_text("x = 1\n")
+
+        mock_add = mocker.patch.object(_cache_hits_counter, "add")
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        oracle_read(str(project_dir / "foo.py"))
+        mock_add.assert_not_called()
+
+
 class DescribeMainEntryPoint:
     """Test the main() entry point."""
 

--- a/packages/oracle/tests/test_server.py
+++ b/packages/oracle/tests/test_server.py
@@ -7,10 +7,9 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
-
 from oracle.project import ProjectState, StackInfo
 from oracle.storage.store import OracleStore
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)

--- a/packages/oracle/tests/test_server.py
+++ b/packages/oracle/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,15 @@ from oracle.project import ProjectState, StackInfo
 from oracle.storage.store import OracleStore
 
 
+@pytest.fixture(autouse=True)
+def _reset_session_tracking() -> Generator[None, None, None]:
+    import oracle.server
+
+    oracle.server._previous_session_id = None
+    yield
+    oracle.server._previous_session_id = None
+
+
 class DescribeServerInit:
     """Verify the MCP server is configured correctly at import time."""
 
@@ -19,7 +29,7 @@ class DescribeServerInit:
         from oracle.server import mcp
 
         tools = await mcp.list_tools()
-        assert len(tools) == 7
+        assert len(tools) == 8
 
     async def it_exposes_all_required_tool_names(self) -> None:
         from oracle.server import mcp
@@ -34,6 +44,7 @@ class DescribeServerInit:
             "oracle_ask",
             "oracle_forget",
             "oracle_stats",
+            "oracle_insights",
         }
         assert tool_names == expected
 
@@ -85,7 +96,36 @@ class DescribeEnsureCaches:
         _ensure_caches(project)
         assert project.command_cache is not None
 
+    def it_wires_tracker_when_missing(self, tmp_path: Path) -> None:
+        from oracle.server import _ensure_caches
+
+        store = OracleStore(tmp_path / "oracle.db")
+        project = ProjectState(
+            root=tmp_path,
+            stack=StackInfo(lang="python"),
+            store=store,
+            session_id="test-sess",
+        )
+        assert project.tracker is None
+        _ensure_caches(project)
+        assert project.tracker is not None
+
+    def it_wires_aggregator_when_missing(self, tmp_path: Path) -> None:
+        from oracle.server import _ensure_caches
+
+        store = OracleStore(tmp_path / "oracle.db")
+        project = ProjectState(
+            root=tmp_path,
+            stack=StackInfo(lang="python"),
+            store=store,
+        )
+        assert project.aggregator is None
+        _ensure_caches(project)
+        assert project.aggregator is not None
+
     def it_does_not_replace_existing_caches(self, tmp_path: Path) -> None:
+        from oracle.analytics.aggregator import SessionAggregator
+        from oracle.analytics.tracker import AnalyticsTracker
         from oracle.cache.command_cache import CommandCache
         from oracle.cache.file_cache import FileCache
         from oracle.cache.git_cache import GitCache
@@ -95,6 +135,8 @@ class DescribeEnsureCaches:
         fc = FileCache(store)
         gc = GitCache(store, tmp_path)
         cc = CommandCache(store, tmp_path)
+        tr = AnalyticsTracker(store, "sess")
+        ag = SessionAggregator(store)
         project = ProjectState(
             root=tmp_path,
             stack=StackInfo(lang="python"),
@@ -102,11 +144,15 @@ class DescribeEnsureCaches:
             file_cache=fc,
             git_cache=gc,
             command_cache=cc,
+            tracker=tr,
+            aggregator=ag,
         )
         _ensure_caches(project)
         assert project.file_cache is fc
         assert project.git_cache is gc
         assert project.command_cache is cc
+        assert project.tracker is tr
+        assert project.aggregator is ag
 
     def it_skips_wiring_when_store_is_none(self) -> None:
         from oracle.server import _ensure_caches
@@ -878,6 +924,61 @@ class DescribeOTelInstrumentation:
         mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
         oracle_read(str(project_dir / "foo.py"))
         mock_add.assert_not_called()
+
+
+class DescribeOracleInsightsTool:
+    """Test the oracle_insights tool function."""
+
+    def it_returns_error_when_no_current_project(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_insights
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        result = oracle_insights()
+        assert "no active project" in result.lower()
+
+    def it_returns_insights_for_active_project(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_insights, oracle_read
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / ".git").mkdir()
+        (project_dir / "main.py").write_text("x = 1\n")
+        mocker.patch("oracle.server._registry", ProjectRegistry(oracle_dir))
+        oracle_read(str(project_dir / "main.py"))
+        result = oracle_insights()
+        assert "no analytics data" in result.lower()
+
+    def it_returns_error_when_store_is_none(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_insights
+
+        oracle_dir = tmp_path / ".oracle"
+        oracle_dir.mkdir()
+        (oracle_dir / "projects").mkdir()
+        registry = ProjectRegistry(oracle_dir)
+        mocker.patch("oracle.server._registry", registry)
+        project = ProjectState(
+            root=tmp_path,
+            stack=StackInfo(lang="python"),
+            store=None,
+        )
+        registry._current = project
+        result = oracle_insights()
+        assert "store not initialized" in result.lower()
 
 
 class DescribeMainEntryPoint:

--- a/packages/oracle/tests/test_stats.py
+++ b/packages/oracle/tests/test_stats.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.storage.store import OracleStore
 
 

--- a/packages/oracle/tests/test_status.py
+++ b/packages/oracle/tests/test_status.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.cache.git_cache import GitCache
 from oracle.project import StackInfo
 from oracle.storage.store import OracleStore

--- a/packages/oracle/tests/test_store.py
+++ b/packages/oracle/tests/test_store.py
@@ -49,8 +49,13 @@ class DescribeOracleStoreInit:
             tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
             assert tables == [
-                "agent_log", "command_results", "file_cache", "file_coaccess",
-                "git_state", "session_profiles", "tool_sequences",
+                "agent_log",
+                "command_results",
+                "file_cache",
+                "file_coaccess",
+                "git_state",
+                "session_profiles",
+                "tool_sequences",
             ]
         finally:
             store2.close()
@@ -64,8 +69,13 @@ class DescribeOracleStoreInit:
             tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
             assert tables == [
-                "agent_log", "command_results", "file_cache", "file_coaccess",
-                "git_state", "session_profiles", "tool_sequences",
+                "agent_log",
+                "command_results",
+                "file_cache",
+                "file_coaccess",
+                "git_state",
+                "session_profiles",
+                "tool_sequences",
             ]
         finally:
             store.close()
@@ -78,12 +88,8 @@ class DescribeAnalyticsTables:
         store = OracleStore(db_path)
         try:
             conn = sqlite3.connect(db_path)
-            cursor = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
-            )
-            tables = sorted(
-                row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_")
-            )
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
             assert "tool_sequences" in tables
             assert "file_coaccess" in tables
@@ -232,3 +238,144 @@ class DescribeEviction:
         store.upsert_file_cache("c.py", b"c", "h3", None, now)  # recent, keep
         count = store.evict_stale_files(max_age_days=30, now=now)
         assert count == 2
+
+
+@pytest.mark.medium
+class DescribeToolSequences:
+    def it_records_a_tool_call_in_sequence(self, store: OracleStore) -> None:
+        store.record_tool_sequence("sess-1", 0, "oracle_read", "main.py", 1000.0)
+        rows = store.get_tool_sequences("sess-1")
+        assert len(rows) == 1
+        assert rows[0]["session_id"] == "sess-1"
+        assert rows[0]["sequence_index"] == 0
+        assert rows[0]["tool_name"] == "oracle_read"
+        assert rows[0]["input_summary"] == "main.py"
+        assert rows[0]["ts"] == 1000.0
+
+    def it_records_multiple_calls_in_order(self, store: OracleStore) -> None:
+        store.record_tool_sequence("sess-1", 0, "oracle_read", "a.py", 1000.0)
+        store.record_tool_sequence("sess-1", 1, "oracle_grep", "pattern", 1001.0)
+        store.record_tool_sequence("sess-1", 2, "oracle_run", "git status", 1002.0)
+        rows = store.get_tool_sequences("sess-1")
+        assert len(rows) == 3
+        assert rows[0]["tool_name"] == "oracle_read"
+        assert rows[1]["tool_name"] == "oracle_grep"
+        assert rows[2]["tool_name"] == "oracle_run"
+
+
+@pytest.mark.medium
+class DescribeFileCoaccess:
+    def it_inserts_a_new_pair(self, store: OracleStore) -> None:
+        store.upsert_file_coaccess("a.py", "b.py", 1000.0)
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 1
+        assert pairs[0]["file_a"] == "a.py"
+        assert pairs[0]["file_b"] == "b.py"
+        assert pairs[0]["session_count"] == 1
+        assert pairs[0]["last_seen"] == 1000.0
+
+    def it_increments_count_on_repeat(self, store: OracleStore) -> None:
+        store.upsert_file_coaccess("a.py", "b.py", 1000.0)
+        store.upsert_file_coaccess("a.py", "b.py", 2000.0)
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 1
+        assert pairs[0]["session_count"] == 2
+
+    def it_enforces_alphabetical_key_order(self, store: OracleStore) -> None:
+        store.upsert_file_coaccess("z.py", "a.py", 1000.0)
+        pairs = store.get_top_coaccess_pairs(limit=10)
+        assert len(pairs) == 1
+        assert pairs[0]["file_a"] == "a.py"
+        assert pairs[0]["file_b"] == "z.py"
+
+    def it_returns_pairs_for_a_specific_file(self, store: OracleStore) -> None:
+        store.upsert_file_coaccess("a.py", "b.py", 1000.0)
+        store.upsert_file_coaccess("a.py", "c.py", 1001.0)
+        store.upsert_file_coaccess("d.py", "e.py", 1002.0)
+        pairs = store.get_coaccess_for_file("a.py")
+        assert len(pairs) == 2
+
+
+@pytest.mark.medium
+class DescribeSessionProfiles:
+    def it_upserts_a_session_profile(self, store: OracleStore) -> None:
+        store.upsert_session_profile("sess-1", 1000.0, 2000.0, '{"oracle_read": 5}', 10, 0.75)
+        profile = store.get_session_profile("sess-1")
+        assert profile is not None
+        assert profile["session_id"] == "sess-1"
+        assert profile["started_at"] == 1000.0
+        assert profile["ended_at"] == 2000.0
+        assert profile["tool_counts"] == '{"oracle_read": 5}'
+        assert profile["files_touched"] == 10
+        assert profile["cache_hit_rate"] == pytest.approx(0.75)
+
+    def it_updates_existing_profile(self, store: OracleStore) -> None:
+        store.upsert_session_profile("sess-1", 1000.0, 2000.0, '{"oracle_read": 5}', 10, 0.75)
+        store.upsert_session_profile("sess-1", 1000.0, 3000.0, '{"oracle_read": 8}', 15, 0.80)
+        profile = store.get_session_profile("sess-1")
+        assert profile is not None
+        assert profile["ended_at"] == 3000.0
+        assert profile["files_touched"] == 15
+
+    def it_returns_none_for_missing_session(self, store: OracleStore) -> None:
+        assert store.get_session_profile("nonexistent") is None
+
+    def it_returns_recent_profiles(self, store: OracleStore) -> None:
+        store.upsert_session_profile("sess-old", 1000.0, 2000.0, "{}", 5, 0.5)
+        store.upsert_session_profile("sess-new", 3000.0, 4000.0, "{}", 8, 0.9)
+        profiles = store.get_recent_session_profiles(limit=20)
+        assert len(profiles) == 2
+        assert profiles[0]["session_id"] == "sess-new"
+        assert profiles[1]["session_id"] == "sess-old"
+
+
+@pytest.mark.medium
+class DescribeSessionLog:
+    def it_returns_all_log_rows_for_a_session(self, store: OracleStore) -> None:
+        store.log_interaction("sess-1", "oracle_read", "a.py", True, 100, 1000)
+        store.log_interaction("sess-1", "oracle_grep", "pattern", False, 0, 2000)
+        store.log_interaction("sess-2", "oracle_read", "b.py", True, 50, 3000)
+        rows = store.get_session_log("sess-1")
+        assert len(rows) == 2
+        assert rows[0]["tool_name"] == "oracle_read"
+        assert rows[1]["tool_name"] == "oracle_grep"
+
+    def it_returns_empty_list_for_unknown_session(self, store: OracleStore) -> None:
+        assert store.get_session_log("nonexistent") == []
+
+    def it_returns_distinct_session_ids(self, store: OracleStore) -> None:
+        store.record_tool_sequence("sess-1", 0, "oracle_read", "a.py", 1000.0)
+        store.record_tool_sequence("sess-1", 1, "oracle_grep", "pat", 1001.0)
+        store.record_tool_sequence("sess-2", 0, "oracle_run", "cmd", 2000.0)
+        ids = store.get_distinct_session_ids()
+        assert sorted(ids) == ["sess-1", "sess-2"]
+
+
+@pytest.mark.medium
+class DescribeRereadQuery:
+    def it_returns_files_read_above_threshold(self, store: OracleStore) -> None:
+        store.log_interaction("sess-1", "oracle_read", "config.py", True, 100, 1000)
+        store.log_interaction("sess-1", "oracle_read", "config.py", True, 100, 2000)
+        store.log_interaction("sess-1", "oracle_read", "config.py", True, 100, 3000)
+        store.log_interaction("sess-1", "oracle_read", "other.py", False, 0, 4000)
+        results = store.get_frequently_reread_files(min_reads=3)
+        assert len(results) == 1
+        assert results[0]["path"] == "config.py"
+        assert results[0]["read_count"] == 3
+
+    def it_returns_empty_when_no_files_above_threshold(self, store: OracleStore) -> None:
+        store.log_interaction("sess-1", "oracle_read", "once.py", False, 0, 1000)
+        results = store.get_frequently_reread_files(min_reads=3)
+        assert results == []
+
+
+@pytest.mark.medium
+class DescribeCacheHitRateQuery:
+    def it_computes_average_from_session_profiles(self, store: OracleStore) -> None:
+        store.upsert_session_profile("sess-1", 1000.0, 2000.0, "{}", 5, 0.6)
+        store.upsert_session_profile("sess-2", 3000.0, 4000.0, "{}", 8, 0.8)
+        avg = store.get_average_cache_hit_rate()
+        assert avg == pytest.approx(0.7)
+
+    def it_returns_zero_when_no_profiles(self, store: OracleStore) -> None:
+        assert store.get_average_cache_hit_rate() == 0.0

--- a/packages/oracle/tests/test_store.py
+++ b/packages/oracle/tests/test_store.py
@@ -8,7 +8,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
 from oracle.storage.store import OracleStore
 
 

--- a/packages/oracle/tests/test_store.py
+++ b/packages/oracle/tests/test_store.py
@@ -48,7 +48,10 @@ class DescribeOracleStoreInit:
             cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
             tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
-            assert tables == ["agent_log", "command_results", "file_cache", "git_state"]
+            assert tables == [
+                "agent_log", "command_results", "file_cache", "file_coaccess",
+                "git_state", "session_profiles", "tool_sequences",
+            ]
         finally:
             store2.close()
 
@@ -60,7 +63,31 @@ class DescribeOracleStoreInit:
             cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
             tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
-            assert tables == ["agent_log", "command_results", "file_cache", "git_state"]
+            assert tables == [
+                "agent_log", "command_results", "file_cache", "file_coaccess",
+                "git_state", "session_profiles", "tool_sequences",
+            ]
+        finally:
+            store.close()
+
+
+@pytest.mark.medium
+class DescribeAnalyticsTables:
+    def it_creates_analytics_tables_on_init(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "analytics_check.db"
+        store = OracleStore(db_path)
+        try:
+            conn = sqlite3.connect(db_path)
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            )
+            tables = sorted(
+                row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_")
+            )
+            conn.close()
+            assert "tool_sequences" in tables
+            assert "file_coaccess" in tables
+            assert "session_profiles" in tables
         finally:
             store.close()
 

--- a/packages/oracle/tests/test_watcher.py
+++ b/packages/oracle/tests/test_watcher.py
@@ -7,10 +7,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from oracle.watcher import OracleWatcher, _source_filter
 from pytest_mock import MockerFixture
 from watchfiles import Change
-
-from oracle.watcher import OracleWatcher, _source_filter
 
 
 async def _fake_awatch(
@@ -31,7 +30,8 @@ async def _fake_awatch(
             return
         # Apply the watch_filter if provided (just like real awatch does)
         if watch_filter:
-            change_set = {(c, p) for c, p in change_set if watch_filter(c, p)}
+            filtered = {(c, p) for c, p in change_set if watch_filter(c, p)}
+            change_set = filtered  # noqa: PLW2901
         if change_set:
             yield change_set
     # Wait for stop signal
@@ -45,7 +45,7 @@ class DescribeOracleWatcher:
         detected: list[str] = []
 
         async def _inner() -> None:
-            watcher = OracleWatcher(Path("/project"), lambda p: detected.append(p))
+            watcher = OracleWatcher(Path("/project"), detected.append)
             mocker.patch("oracle.watcher.awatch", new=_fake_awatch)
             task = asyncio.create_task(watcher.start())
             await asyncio.sleep(0.1)
@@ -61,7 +61,7 @@ class DescribeOracleWatcher:
         detected: list[str] = []
 
         async def _inner() -> None:
-            watcher = OracleWatcher(Path("/project"), lambda p: detected.append(p))
+            watcher = OracleWatcher(Path("/project"), detected.append)
             mocker.patch("oracle.watcher.awatch", new=_fake_awatch)
             task = asyncio.create_task(watcher.start())
             await asyncio.sleep(0.1)

--- a/packages/shared/pyproject.toml
+++ b/packages/shared/pyproject.toml
@@ -2,6 +2,11 @@
 name = "mcp-shared"
 version = "0.1.0"
 requires-python = ">=3.12"
+dependencies = [
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20",
+]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.24"]

--- a/packages/shared/src/mcp_shared/__init__.py
+++ b/packages/shared/src/mcp_shared/__init__.py
@@ -1,12 +1,17 @@
 from mcp_shared.git_helpers import get_remote_url, git_cmd
 from mcp_shared.project_detect import StackInfo, detect_project_root, detect_stack
 from mcp_shared.storage_base import SQLiteBase
+from mcp_shared.telemetry import get_meter, get_tracer, init_telemetry, trace_tool
 
 __all__ = [
     "SQLiteBase",
     "StackInfo",
     "detect_project_root",
     "detect_stack",
+    "get_meter",
     "get_remote_url",
+    "get_tracer",
     "git_cmd",
+    "init_telemetry",
+    "trace_tool",
 ]

--- a/packages/shared/src/mcp_shared/git_helpers.py
+++ b/packages/shared/src/mcp_shared/git_helpers.py
@@ -19,6 +19,7 @@ def git_cmd(args: list[str], cwd: Path) -> str:
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
         )
     except (subprocess.TimeoutExpired, OSError):
         logger.warning("git command failed: %s", args, exc_info=True)

--- a/packages/shared/src/mcp_shared/telemetry.py
+++ b/packages/shared/src/mcp_shared/telemetry.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import functools
 import os
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from opentelemetry import metrics, trace
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter

--- a/packages/shared/src/mcp_shared/telemetry.py
+++ b/packages/shared/src/mcp_shared/telemetry.py
@@ -1,0 +1,83 @@
+"""OpenTelemetry infrastructure for MCP servers — traces, metrics, and logs to SigNoz."""
+
+from __future__ import annotations
+
+import functools
+import os
+from typing import Any, Callable, TypeVar
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_DEFAULT_ENDPOINT = "http://signoz.local:4317"
+_initialized = False
+
+
+def _is_enabled() -> bool:
+    return os.environ.get("ORACLE_TELEMETRY_ENABLED", "true").lower() != "false"
+
+
+def init_telemetry(service_name: str) -> None:
+    global _initialized
+    if _initialized or not _is_enabled():
+        return
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", _DEFAULT_ENDPOINT)
+    resource = Resource.create({"service.name": service_name})
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, insecure=True))
+    )
+    trace.set_tracer_provider(tracer_provider)
+
+    meter_provider = MeterProvider(
+        resource=resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=endpoint, insecure=True),
+                export_interval_millis=30000,
+            )
+        ],
+    )
+    metrics.set_meter_provider(meter_provider)
+
+    _initialized = True
+
+
+def get_tracer(name: str) -> trace.Tracer:
+    return trace.get_tracer(name)
+
+
+def get_meter(name: str) -> metrics.Meter:
+    return metrics.get_meter(name)
+
+
+def trace_tool(tool_name: str) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer("mcp.tools")
+            with tracer.start_as_current_span(f"mcp.tool.{tool_name}") as span:
+                span.set_attribute("mcp.tool.name", tool_name)
+                try:
+                    result = func(*args, **kwargs)
+                    if isinstance(result, str):
+                        span.set_attribute("mcp.tool.result_length", len(result))
+                    return result
+                except Exception as exc:
+                    span.record_exception(exc)
+                    span.set_status(trace.StatusCode.ERROR, str(exc))
+                    raise
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/packages/shared/tests/test_git_helpers.py
+++ b/packages/shared/tests/test_git_helpers.py
@@ -36,8 +36,6 @@ class TestGetRemoteUrl:
         assert result is None
 
     def test_ssh_url_without_dot_git(self, tmp_path: object) -> None:
-        with patch(
-            "mcp_shared.git_helpers.git_cmd", return_value="git@github.com:owner/repo\n"
-        ):
+        with patch("mcp_shared.git_helpers.git_cmd", return_value="git@github.com:owner/repo\n"):
             result = get_remote_url(tmp_path)  # type: ignore[arg-type]
         assert result == "owner/repo"

--- a/packages/shared/tests/test_git_helpers.py
+++ b/packages/shared/tests/test_git_helpers.py
@@ -7,7 +7,10 @@ from mcp_shared.git_helpers import get_remote_url
 
 class TestGetRemoteUrl:
     def test_ssh_url_normalized(self, tmp_path: object) -> None:
-        with patch("mcp_shared.git_helpers.git_cmd", return_value="git@github.com:owner/repo.git\n"):
+        with patch(
+            "mcp_shared.git_helpers.git_cmd",
+            return_value="git@github.com:owner/repo.git\n",
+        ):
             result = get_remote_url(tmp_path)  # type: ignore[arg-type]
         assert result == "owner/repo"
 
@@ -33,6 +36,8 @@ class TestGetRemoteUrl:
         assert result is None
 
     def test_ssh_url_without_dot_git(self, tmp_path: object) -> None:
-        with patch("mcp_shared.git_helpers.git_cmd", return_value="git@github.com:owner/repo\n"):
+        with patch(
+            "mcp_shared.git_helpers.git_cmd", return_value="git@github.com:owner/repo\n"
+        ):
             result = get_remote_url(tmp_path)  # type: ignore[arg-type]
         assert result == "owner/repo"

--- a/packages/shared/tests/test_telemetry.py
+++ b/packages/shared/tests/test_telemetry.py
@@ -1,0 +1,81 @@
+"""Tests for OpenTelemetry infrastructure."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from mcp_shared.telemetry import (
+    _is_enabled,
+    get_meter,
+    get_tracer,
+    init_telemetry,
+    trace_tool,
+)
+
+
+class TestTelemetryEnabled:
+    def test_returns_true_by_default(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert _is_enabled() is True
+
+    def test_returns_false_when_disabled(self) -> None:
+        with patch.dict(os.environ, {"ORACLE_TELEMETRY_ENABLED": "false"}):
+            assert _is_enabled() is False
+
+    def test_is_case_insensitive(self) -> None:
+        with patch.dict(os.environ, {"ORACLE_TELEMETRY_ENABLED": "FALSE"}):
+            assert _is_enabled() is False
+
+
+class TestGetTracer:
+    def test_returns_a_tracer(self) -> None:
+        tracer = get_tracer("test")
+        assert tracer is not None
+
+
+class TestGetMeter:
+    def test_returns_a_meter(self) -> None:
+        meter = get_meter("test")
+        assert meter is not None
+
+
+class TestTraceTool:
+    def test_wraps_function_and_returns_result(self) -> None:
+        @trace_tool("test_tool")
+        def my_tool(x: int) -> str:
+            return f"result-{x}"
+
+        assert my_tool(42) == "result-42"
+
+    def test_preserves_function_name(self) -> None:
+        @trace_tool("test_tool")
+        def my_tool() -> str:
+            return "ok"
+
+        assert my_tool.__name__ == "my_tool"
+
+    def test_propagates_exceptions(self) -> None:
+        @trace_tool("failing_tool")
+        def bad_tool() -> str:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            bad_tool()
+
+
+class TestInitTelemetry:
+    def test_is_idempotent(self) -> None:
+        with patch.dict(os.environ, {"ORACLE_TELEMETRY_ENABLED": "false"}):
+            init_telemetry("test-service")
+            init_telemetry("test-service")
+
+    def test_skips_when_disabled(self) -> None:
+        with patch.dict(os.environ, {"ORACLE_TELEMETRY_ENABLED": "false"}):
+            import mcp_shared.telemetry as mod
+
+            mod._initialized = False
+            init_telemetry("test-service")
+            assert mod._initialized is False

--- a/packages/shared/tests/test_telemetry.py
+++ b/packages/shared/tests/test_telemetry.py
@@ -6,7 +6,6 @@ import os
 from unittest.mock import patch
 
 import pytest
-
 from mcp_shared.telemetry import (
     _is_enabled,
     get_meter,

--- a/packages/webhook/src/github_webhook_mcp/__main__.py
+++ b/packages/webhook/src/github_webhook_mcp/__main__.py
@@ -47,8 +47,8 @@ async def _run() -> None:
         reactor.auto_review_repo,
         reactor.debounce_seconds,
     )
-    asyncio.create_task(smee.listen())
-    asyncio.create_task(_prune_loop(store, settings.prune_days))
+    _smee_task = asyncio.create_task(smee.listen())  # noqa: RUF006
+    _prune_task = asyncio.create_task(_prune_loop(store, settings.prune_days))  # noqa: RUF006
 
     logger.info("Starting MCP server on port %d", settings.mcp_port)
     await mcp.run_async(transport="sse", port=settings.mcp_port)

--- a/packages/webhook/src/github_webhook_mcp/__main__.py
+++ b/packages/webhook/src/github_webhook_mcp/__main__.py
@@ -42,7 +42,11 @@ async def _run() -> None:
     )
 
     logger.info("Starting Smee listener for %s", settings.smee_channel_url)
-    logger.info("PR reactor active for %s (debounce: %ds)", reactor.auto_review_repo, reactor.debounce_seconds)
+    logger.info(
+        "PR reactor active for %s (debounce: %ds)",
+        reactor.auto_review_repo,
+        reactor.debounce_seconds,
+    )
     asyncio.create_task(smee.listen())
     asyncio.create_task(_prune_loop(store, settings.prune_days))
 

--- a/packages/webhook/src/github_webhook_mcp/reactor.py
+++ b/packages/webhook/src/github_webhook_mcp/reactor.py
@@ -113,7 +113,7 @@ class PRReactor:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                stdout, stderr = await review_process.communicate()
+                _stdout, stderr = await review_process.communicate()
                 if review_process.returncode == 0:
                     logger.info("Review complete for %s#%d", repo, pr_number)
                     span.set_attribute("reactor.review_success", True)

--- a/packages/webhook/src/github_webhook_mcp/reactor.py
+++ b/packages/webhook/src/github_webhook_mcp/reactor.py
@@ -16,8 +16,10 @@ def _get_tracer() -> trace.Tracer:
     global _tracer
     if _tracer is None:
         from .telemetry import get_tracer
+
         _tracer = get_tracer("webhook.reactor")
     return _tracer
+
 
 AUTO_REVIEW_REPO = "SayMoreAI/saymore"
 DEFAULT_DEBOUNCE_SECONDS = 900  # 15 minutes
@@ -76,7 +78,9 @@ class PRReactor:
                 )
                 logger.info(
                     "PR %s#%d pushed — review scheduled in %ds",
-                    repo, pr_number, self.debounce_seconds,
+                    repo,
+                    pr_number,
+                    self.debounce_seconds,
                 )
 
     def _cancel_timer(self, timer_key: str) -> None:
@@ -101,8 +105,11 @@ class PRReactor:
             logger.info("Spawning review for %s#%d", repo, pr_number)
             try:
                 review_process = await asyncio.create_subprocess_exec(
-                    "claude", "-p", f"/review-pr {pr_number}",
-                    "--cwd", self.repo_path,
+                    "claude",
+                    "-p",
+                    f"/review-pr {pr_number}",
+                    "--cwd",
+                    self.repo_path,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -113,7 +120,9 @@ class PRReactor:
                 else:
                     logger.warning(
                         "Review failed for %s#%d (exit %d): %s",
-                        repo, pr_number, review_process.returncode,
+                        repo,
+                        pr_number,
+                        review_process.returncode,
                         stderr.decode()[:500],
                     )
                     span.set_attribute("reactor.review_success", False)

--- a/packages/webhook/src/github_webhook_mcp/reactor.py
+++ b/packages/webhook/src/github_webhook_mcp/reactor.py
@@ -5,7 +5,19 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from opentelemetry import trace
+
 logger = logging.getLogger(__name__)
+
+_tracer: trace.Tracer | None = None
+
+
+def _get_tracer() -> trace.Tracer:
+    global _tracer
+    if _tracer is None:
+        from .telemetry import get_tracer
+        _tracer = get_tracer("webhook.reactor")
+    return _tracer
 
 AUTO_REVIEW_REPO = "SayMoreAI/saymore"
 DEFAULT_DEBOUNCE_SECONDS = 900  # 15 minutes
@@ -38,25 +50,34 @@ class PRReactor:
             pr_number: The pull-request number.
             action: The webhook action (e.g. ``"opened"``, ``"synchronize"``).
         """
-        if repo != self.auto_review_repo:
-            return
+        tracer = _get_tracer()
+        with tracer.start_as_current_span("reactor.on_pr_event") as span:
+            span.set_attribute("reactor.repo", repo)
+            span.set_attribute("reactor.pr_number", pr_number)
+            span.set_attribute("reactor.action", action)
 
-        timer_key = f"{repo}:{pr_number}"
+            if repo != self.auto_review_repo:
+                span.set_attribute("reactor.skipped", True)
+                return
 
-        if action == "opened":
-            self._cancel_timer(timer_key)
-            await self._spawn_review(repo, pr_number)
-        elif action == "synchronize":
-            self._cancel_timer(timer_key)
-            loop = asyncio.get_running_loop()
-            self._timers[timer_key] = loop.call_later(
-                self.debounce_seconds,
-                lambda: asyncio.ensure_future(self._spawn_review(repo, pr_number)),
-            )
-            logger.info(
-                "PR %s#%d pushed — review scheduled in %ds",
-                repo, pr_number, self.debounce_seconds,
-            )
+            timer_key = f"{repo}:{pr_number}"
+
+            if action == "opened":
+                span.set_attribute("reactor.trigger", "immediate")
+                self._cancel_timer(timer_key)
+                await self._spawn_review(repo, pr_number)
+            elif action == "synchronize":
+                span.set_attribute("reactor.trigger", "debounced")
+                self._cancel_timer(timer_key)
+                loop = asyncio.get_running_loop()
+                self._timers[timer_key] = loop.call_later(
+                    self.debounce_seconds,
+                    lambda: asyncio.ensure_future(self._spawn_review(repo, pr_number)),
+                )
+                logger.info(
+                    "PR %s#%d pushed — review scheduled in %ds",
+                    repo, pr_number, self.debounce_seconds,
+                )
 
     def _cancel_timer(self, timer_key: str) -> None:
         """Cancel a pending debounce timer, if one exists for *timer_key*."""
@@ -71,23 +92,33 @@ class PRReactor:
             repo: The full repository name (``owner/repo``).
             pr_number: The pull-request number to review.
         """
-        self._timers.pop(f"{repo}:{pr_number}", None)
-        logger.info("Spawning review for %s#%d", repo, pr_number)
-        try:
-            review_process = await asyncio.create_subprocess_exec(
-                "claude", "-p", f"/review-pr {pr_number}",
-                "--cwd", self.repo_path,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await review_process.communicate()
-            if review_process.returncode == 0:
-                logger.info("Review complete for %s#%d", repo, pr_number)
-            else:
-                logger.warning(
-                    "Review failed for %s#%d (exit %d): %s",
-                    repo, pr_number, review_process.returncode,
-                    stderr.decode()[:500],
+        tracer = _get_tracer()
+        with tracer.start_as_current_span("reactor.spawn_review") as span:
+            span.set_attribute("reactor.repo", repo)
+            span.set_attribute("reactor.pr_number", pr_number)
+
+            self._timers.pop(f"{repo}:{pr_number}", None)
+            logger.info("Spawning review for %s#%d", repo, pr_number)
+            try:
+                review_process = await asyncio.create_subprocess_exec(
+                    "claude", "-p", f"/review-pr {pr_number}",
+                    "--cwd", self.repo_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
                 )
-        except FileNotFoundError:
-            logger.error("claude CLI not found — cannot spawn review")
+                stdout, stderr = await review_process.communicate()
+                if review_process.returncode == 0:
+                    logger.info("Review complete for %s#%d", repo, pr_number)
+                    span.set_attribute("reactor.review_success", True)
+                else:
+                    logger.warning(
+                        "Review failed for %s#%d (exit %d): %s",
+                        repo, pr_number, review_process.returncode,
+                        stderr.decode()[:500],
+                    )
+                    span.set_attribute("reactor.review_success", False)
+                    span.set_attribute("reactor.exit_code", review_process.returncode)
+            except FileNotFoundError:
+                logger.error("claude CLI not found — cannot spawn review")
+                span.record_exception(FileNotFoundError("claude CLI not found"))
+                span.set_status(trace.StatusCode.ERROR, "claude CLI not found")

--- a/packages/webhook/src/github_webhook_mcp/server.py
+++ b/packages/webhook/src/github_webhook_mcp/server.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from fastmcp import FastMCP
 
@@ -25,7 +25,7 @@ def init_server(store: EventStore, username: str = "mikelane") -> None:
         store: The initialized :class:`EventStore` to query.
         username: The GitHub username used to filter review requests.
     """
-    global _store, _username  # noqa: PLW0603
+    global _store, _username
     _store = store
     _username = username
 
@@ -39,7 +39,7 @@ def _require_store() -> EventStore:
 
 def _default_since() -> datetime:
     """Return a timestamp 24 hours ago in UTC."""
-    return datetime.now(timezone.utc) - timedelta(hours=24)
+    return datetime.now(UTC) - timedelta(hours=24)
 
 
 @mcp.tool()
@@ -73,9 +73,7 @@ async def get_pending_reviews(repo: str | None = None) -> str:
             }
         )
 
-    query_results_counter.add(
-        len(pending_reviews), {"tool.name": "get_pending_reviews"}
-    )
+    query_results_counter.add(len(pending_reviews), {"tool.name": "get_pending_reviews"})
     return json.dumps(pending_reviews, indent=2)
 
 
@@ -115,9 +113,7 @@ async def get_review_feedback(pr_number: int, repo: str) -> str:
             }
         )
 
-    query_results_counter.add(
-        len(feedback_entries), {"tool.name": "get_review_feedback"}
-    )
+    query_results_counter.add(len(feedback_entries), {"tool.name": "get_review_feedback"})
     return json.dumps(feedback_entries, indent=2)
 
 
@@ -156,8 +152,7 @@ async def get_ci_status(pr_number: int | None = None, repo: str | None = None) -
                     "conclusion": conclusion,
                     "url": ci_run_payload.get("html_url"),
                     "pr_numbers": [
-                        pr.get("number")
-                        for pr in ci_run_payload.get("pull_requests", [])
+                        pr.get("number") for pr in ci_run_payload.get("pull_requests", [])
                     ],
                     "completed_at": webhook_event.received_at.isoformat(),
                 }
@@ -214,31 +209,28 @@ async def get_notifications(since: str | None = None) -> str:
     since_dt = datetime.fromisoformat(since) if since else _default_since()
     events = await _require_store().get_events(since=since_dt)
 
-    notification_summaries = []
-    for webhook_event in events:
-        notification_summaries.append(
-            {
-                "repo": webhook_event.repo,
-                "event_type": webhook_event.event_type,
-                "action": webhook_event.action,
-                "sender": webhook_event.sender,
-                "received_at": webhook_event.received_at.isoformat(),
-                "summary": " ".join(
-                    filter(
-                        None,
-                        [
-                            webhook_event.sender,
-                            webhook_event.action,
-                            webhook_event.event_type,
-                            "on",
-                            webhook_event.repo,
-                        ],
-                    )
-                ),
-            }
-        )
+    notification_summaries = [
+        {
+            "repo": webhook_event.repo,
+            "event_type": webhook_event.event_type,
+            "action": webhook_event.action,
+            "sender": webhook_event.sender,
+            "received_at": webhook_event.received_at.isoformat(),
+            "summary": " ".join(
+                filter(
+                    None,
+                    [
+                        webhook_event.sender,
+                        webhook_event.action,
+                        webhook_event.event_type,
+                        "on",
+                        webhook_event.repo,
+                    ],
+                )
+            ),
+        }
+        for webhook_event in events
+    ]
 
-    query_results_counter.add(
-        len(notification_summaries), {"tool.name": "get_notifications"}
-    )
+    query_results_counter.add(len(notification_summaries), {"tool.name": "get_notifications"})
     return json.dumps(notification_summaries, indent=2)

--- a/packages/webhook/src/github_webhook_mcp/server.py
+++ b/packages/webhook/src/github_webhook_mcp/server.py
@@ -8,6 +8,9 @@ from datetime import datetime, timedelta, timezone
 from fastmcp import FastMCP
 
 from .storage import EventStore
+from .telemetry import init_webhook_telemetry, query_results_counter, trace_tool_async
+
+init_webhook_telemetry()
 
 mcp = FastMCP("github-webhooks")
 
@@ -40,6 +43,7 @@ def _default_since() -> datetime:
 
 
 @mcp.tool()
+@trace_tool_async("get_pending_reviews")
 async def get_pending_reviews(repo: str | None = None) -> str:
     """Get pull requests awaiting my review.
 
@@ -67,10 +71,12 @@ async def get_pending_reviews(repo: str | None = None) -> str:
             "requested_at": webhook_event.received_at.isoformat(),
         })
 
+    query_results_counter.add(len(pending_reviews), {"tool.name": "get_pending_reviews"})
     return json.dumps(pending_reviews, indent=2)
 
 
 @mcp.tool()
+@trace_tool_async("get_review_feedback")
 async def get_review_feedback(pr_number: int, repo: str) -> str:
     """Get review comments on a specific pull request.
 
@@ -103,10 +109,12 @@ async def get_review_feedback(pr_number: int, repo: str) -> str:
             "submitted_at": webhook_event.received_at.isoformat(),
         })
 
+    query_results_counter.add(len(feedback_entries), {"tool.name": "get_review_feedback"})
     return json.dumps(feedback_entries, indent=2)
 
 
 @mcp.tool()
+@trace_tool_async("get_ci_status")
 async def get_ci_status(pr_number: int | None = None, repo: str | None = None) -> str:
     """Get CI/CD status, filtered to failures by default.
 
@@ -138,10 +146,12 @@ async def get_ci_status(pr_number: int | None = None, repo: str | None = None) -
                 "completed_at": webhook_event.received_at.isoformat(),
             })
 
+    query_results_counter.add(len(ci_failures), {"tool.name": "get_ci_status"})
     return json.dumps(ci_failures, indent=2)
 
 
 @mcp.tool()
+@trace_tool_async("get_new_prs")
 async def get_new_prs(repo: str | None = None, since: str | None = None) -> str:
     """Get recently opened pull requests.
 
@@ -170,10 +180,12 @@ async def get_new_prs(repo: str | None = None, since: str | None = None) -> str:
             "opened_at": webhook_event.received_at.isoformat(),
         })
 
+    query_results_counter.add(len(opened_prs), {"tool.name": "get_new_prs"})
     return json.dumps(opened_prs, indent=2)
 
 
 @mcp.tool()
+@trace_tool_async("get_notifications")
 async def get_notifications(since: str | None = None) -> str:
     """Get all webhook events since a given time, grouped by repo.
 
@@ -194,4 +206,5 @@ async def get_notifications(since: str | None = None) -> str:
             "summary": " ".join(filter(None, [webhook_event.sender, webhook_event.action, webhook_event.event_type, "on", webhook_event.repo])),
         })
 
+    query_results_counter.add(len(notification_summaries), {"tool.name": "get_notifications"})
     return json.dumps(notification_summaries, indent=2)

--- a/packages/webhook/src/github_webhook_mcp/server.py
+++ b/packages/webhook/src/github_webhook_mcp/server.py
@@ -62,16 +62,20 @@ async def get_pending_reviews(repo: str | None = None) -> str:
         if reviewer.get("login") != _username:
             continue
         pr = webhook_event.payload.get("pull_request", {})
-        pending_reviews.append({
-            "repo": webhook_event.repo,
-            "number": pr.get("number"),
-            "title": pr.get("title"),
-            "url": pr.get("html_url"),
-            "author": pr.get("user", {}).get("login"),
-            "requested_at": webhook_event.received_at.isoformat(),
-        })
+        pending_reviews.append(
+            {
+                "repo": webhook_event.repo,
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "url": pr.get("html_url"),
+                "author": pr.get("user", {}).get("login"),
+                "requested_at": webhook_event.received_at.isoformat(),
+            }
+        )
 
-    query_results_counter.add(len(pending_reviews), {"tool.name": "get_pending_reviews"})
+    query_results_counter.add(
+        len(pending_reviews), {"tool.name": "get_pending_reviews"}
+    )
     return json.dumps(pending_reviews, indent=2)
 
 
@@ -100,16 +104,20 @@ async def get_review_feedback(pr_number: int, repo: str) -> str:
             continue
         review = webhook_event.payload.get("review", {})
         comment = webhook_event.payload.get("comment", {})
-        feedback_entries.append({
-            "repo": webhook_event.repo,
-            "pr_number": pr_number,
-            "author": (review or comment).get("user", {}).get("login"),
-            "state": review.get("state"),
-            "body": (review or comment).get("body", ""),
-            "submitted_at": webhook_event.received_at.isoformat(),
-        })
+        feedback_entries.append(
+            {
+                "repo": webhook_event.repo,
+                "pr_number": pr_number,
+                "author": (review or comment).get("user", {}).get("login"),
+                "state": review.get("state"),
+                "body": (review or comment).get("body", ""),
+                "submitted_at": webhook_event.received_at.isoformat(),
+            }
+        )
 
-    query_results_counter.add(len(feedback_entries), {"tool.name": "get_review_feedback"})
+    query_results_counter.add(
+        len(feedback_entries), {"tool.name": "get_review_feedback"}
+    )
     return json.dumps(feedback_entries, indent=2)
 
 
@@ -127,7 +135,11 @@ async def get_ci_status(pr_number: int | None = None, repo: str | None = None) -
     for event_type in ("check_run", "check_suite", "workflow_run"):
         events = await _require_store().get_events(repo=repo, event_type=event_type)
         for webhook_event in events:
-            ci_run_payload = webhook_event.payload.get("check_run") or webhook_event.payload.get("check_suite") or webhook_event.payload.get("workflow_run", {})
+            ci_run_payload = (
+                webhook_event.payload.get("check_run")
+                or webhook_event.payload.get("check_suite")
+                or webhook_event.payload.get("workflow_run", {})
+            )
             conclusion = ci_run_payload.get("conclusion")
             if conclusion not in ("failure", "timed_out", "cancelled"):
                 continue
@@ -137,14 +149,19 @@ async def get_ci_status(pr_number: int | None = None, repo: str | None = None) -
                 if not any(pr.get("number") == pr_number for pr in associated_prs):
                     continue
 
-            ci_failures.append({
-                "repo": webhook_event.repo,
-                "name": ci_run_payload.get("name"),
-                "conclusion": conclusion,
-                "url": ci_run_payload.get("html_url"),
-                "pr_numbers": [pr.get("number") for pr in ci_run_payload.get("pull_requests", [])],
-                "completed_at": webhook_event.received_at.isoformat(),
-            })
+            ci_failures.append(
+                {
+                    "repo": webhook_event.repo,
+                    "name": ci_run_payload.get("name"),
+                    "conclusion": conclusion,
+                    "url": ci_run_payload.get("html_url"),
+                    "pr_numbers": [
+                        pr.get("number")
+                        for pr in ci_run_payload.get("pull_requests", [])
+                    ],
+                    "completed_at": webhook_event.received_at.isoformat(),
+                }
+            )
 
     query_results_counter.add(len(ci_failures), {"tool.name": "get_ci_status"})
     return json.dumps(ci_failures, indent=2)
@@ -171,14 +188,16 @@ async def get_new_prs(repo: str | None = None, since: str | None = None) -> str:
     opened_prs = []
     for webhook_event in events:
         pr = webhook_event.payload.get("pull_request", {})
-        opened_prs.append({
-            "repo": webhook_event.repo,
-            "number": pr.get("number"),
-            "title": pr.get("title"),
-            "url": pr.get("html_url"),
-            "author": pr.get("user", {}).get("login"),
-            "opened_at": webhook_event.received_at.isoformat(),
-        })
+        opened_prs.append(
+            {
+                "repo": webhook_event.repo,
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "url": pr.get("html_url"),
+                "author": pr.get("user", {}).get("login"),
+                "opened_at": webhook_event.received_at.isoformat(),
+            }
+        )
 
     query_results_counter.add(len(opened_prs), {"tool.name": "get_new_prs"})
     return json.dumps(opened_prs, indent=2)
@@ -197,14 +216,29 @@ async def get_notifications(since: str | None = None) -> str:
 
     notification_summaries = []
     for webhook_event in events:
-        notification_summaries.append({
-            "repo": webhook_event.repo,
-            "event_type": webhook_event.event_type,
-            "action": webhook_event.action,
-            "sender": webhook_event.sender,
-            "received_at": webhook_event.received_at.isoformat(),
-            "summary": " ".join(filter(None, [webhook_event.sender, webhook_event.action, webhook_event.event_type, "on", webhook_event.repo])),
-        })
+        notification_summaries.append(
+            {
+                "repo": webhook_event.repo,
+                "event_type": webhook_event.event_type,
+                "action": webhook_event.action,
+                "sender": webhook_event.sender,
+                "received_at": webhook_event.received_at.isoformat(),
+                "summary": " ".join(
+                    filter(
+                        None,
+                        [
+                            webhook_event.sender,
+                            webhook_event.action,
+                            webhook_event.event_type,
+                            "on",
+                            webhook_event.repo,
+                        ],
+                    )
+                ),
+            }
+        )
 
-    query_results_counter.add(len(notification_summaries), {"tool.name": "get_notifications"})
+    query_results_counter.add(
+        len(notification_summaries), {"tool.name": "get_notifications"}
+    )
     return json.dumps(notification_summaries, indent=2)

--- a/packages/webhook/src/github_webhook_mcp/signature.py
+++ b/packages/webhook/src/github_webhook_mcp/signature.py
@@ -20,7 +20,5 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     """
     if not signature.startswith("sha256="):
         return False
-    expected = (
-        "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
-    )
+    expected = "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature)

--- a/packages/webhook/src/github_webhook_mcp/signature.py
+++ b/packages/webhook/src/github_webhook_mcp/signature.py
@@ -20,7 +20,7 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     """
     if not signature.startswith("sha256="):
         return False
-    expected = "sha256=" + hmac.new(
-        secret.encode(), payload, hashlib.sha256
-    ).hexdigest()
+    expected = (
+        "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    )
     return hmac.compare_digest(expected, signature)

--- a/packages/webhook/src/github_webhook_mcp/smee_client.py
+++ b/packages/webhook/src/github_webhook_mcp/smee_client.py
@@ -141,8 +141,8 @@ class SmeeClient:
                 with _tracer.start_as_current_span("smee.connection") as conn_span:
                     conn_span.set_attribute("smee.channel_url", self.channel_url)
                     async with (
-                        httpx.AsyncClient(timeout=None) as client,
-                        aconnect_sse(  # noqa: S113
+                        httpx.AsyncClient(timeout=None) as client,  # noqa: S113
+                        aconnect_sse(
                             client, "GET", self.channel_url
                         ) as source,
                     ):

--- a/packages/webhook/src/github_webhook_mcp/smee_client.py
+++ b/packages/webhook/src/github_webhook_mcp/smee_client.py
@@ -14,8 +14,11 @@ from httpx_sse import aconnect_sse
 from .models import SmeeEvent, WebhookEvent
 from .signature import verify_signature
 from .storage import EventStore
+from .telemetry import events_received_counter, get_tracer
 
 logger = logging.getLogger(__name__)
+
+_tracer = get_tracer("webhook.smee_client")
 
 
 @runtime_checkable
@@ -61,60 +64,72 @@ class SmeeClient:
         Args:
             raw_data: The raw JSON string from the Smee.io SSE stream.
         """
-        try:
-            smee_envelope = json.loads(raw_data)
-        except json.JSONDecodeError:
-            logger.warning("Received non-JSON SSE data, skipping")
-            return
+        with _tracer.start_as_current_span("smee.process_message") as span:
+            try:
+                smee_envelope = json.loads(raw_data)
+            except json.JSONDecodeError:
+                logger.warning("Received non-JSON SSE data, skipping")
+                return
 
-        if "body" not in smee_envelope:
-            return
+            if "body" not in smee_envelope:
+                return
 
-        event = SmeeEvent(
-            body=smee_envelope["body"],
-            x_github_event=smee_envelope.get("x-github-event"),
-            x_github_delivery=smee_envelope.get("x-github-delivery"),
-            x_hub_signature_256=smee_envelope.get("x-hub-signature-256"),
-        )
-
-        if not event.repo_full_name:
-            logger.debug(
-                "Event has no repository, skipping: %s", event.x_github_delivery
-            )
-            return
-
-        # Signature verification is best-effort with Smee.io. Smee re-serializes
-        # the JSON body, so json.dumps() produces different bytes than what GitHub
-        # originally signed. The Smee channel URL itself is the security boundary.
-        payload_bytes = json.dumps(event.body).encode()
-        if event.x_hub_signature_256 and not verify_signature(
-            payload_bytes, event.x_hub_signature_256, self.webhook_secret
-        ):
-            logger.debug(
-                "Signature mismatch for delivery %s (expected with Smee proxy)",
-                event.x_github_delivery,
+            event = SmeeEvent(
+                body=smee_envelope["body"],
+                x_github_event=smee_envelope.get("x-github-event"),
+                x_github_delivery=smee_envelope.get("x-github-delivery"),
+                x_hub_signature_256=smee_envelope.get("x-hub-signature-256"),
             )
 
-        webhook_event = WebhookEvent(
-            received_at=datetime.now(timezone.utc),
-            delivery_id=event.x_github_delivery or "",
-            repo=event.repo_full_name,
-            event_type=event.x_github_event or "unknown",
-            action=event.action,
-            sender=event.sender_login,
-            payload=event.body,
-        )
+            if not event.repo_full_name:
+                logger.debug(
+                    "Event has no repository, skipping: %s", event.x_github_delivery
+                )
+                return
 
-        await self.store.store_event(webhook_event)
+            span.set_attribute("smee.event_type", event.x_github_event or "unknown")
+            span.set_attribute("smee.delivery_id", event.x_github_delivery or "")
+            span.set_attribute("smee.repo", event.repo_full_name)
 
-        if self.reactor and webhook_event.event_type == "pull_request" and webhook_event.action:
-            pr_number = webhook_event.payload.get("number")
-            if isinstance(pr_number, int):
-                await self.reactor.on_pr_event(
-                    webhook_event.repo, pr_number, webhook_event.action
+            # Signature verification is best-effort with Smee.io. Smee re-serializes
+            # the JSON body, so json.dumps() produces different bytes than what GitHub
+            # originally signed. The Smee channel URL itself is the security boundary.
+            payload_bytes = json.dumps(event.body).encode()
+            if event.x_hub_signature_256 and not verify_signature(
+                payload_bytes, event.x_hub_signature_256, self.webhook_secret
+            ):
+                logger.debug(
+                    "Signature mismatch for delivery %s (expected with Smee proxy)",
+                    event.x_github_delivery,
                 )
 
-        self._backoff = 1.0
+            webhook_event = WebhookEvent(
+                received_at=datetime.now(timezone.utc),
+                delivery_id=event.x_github_delivery or "",
+                repo=event.repo_full_name,
+                event_type=event.x_github_event or "unknown",
+                action=event.action,
+                sender=event.sender_login,
+                payload=event.body,
+            )
+
+            await self.store.store_event(webhook_event)
+            events_received_counter.add(
+                1,
+                {
+                    "event.type": webhook_event.event_type,
+                    "event.repo": webhook_event.repo,
+                },
+            )
+
+            if self.reactor and webhook_event.event_type == "pull_request" and webhook_event.action:
+                pr_number = webhook_event.payload.get("number")
+                if isinstance(pr_number, int):
+                    await self.reactor.on_pr_event(
+                        webhook_event.repo, pr_number, webhook_event.action
+                    )
+
+            self._backoff = 1.0
 
     async def listen(self) -> None:
         """Connect to the Smee channel and process events indefinitely.
@@ -125,14 +140,16 @@ class SmeeClient:
         while True:
             try:
                 logger.info("Connecting to Smee channel: %s", self.channel_url)
-                async with httpx.AsyncClient(timeout=None) as client:
-                    async with aconnect_sse(
-                        client, "GET", self.channel_url
-                    ) as source:
-                        self._backoff = 1.0
-                        async for sse_event in source.aiter_sse():
-                            if sse_event.data:
-                                await self.process_sse_message(sse_event.data)
+                with _tracer.start_as_current_span("smee.connection") as conn_span:
+                    conn_span.set_attribute("smee.channel_url", self.channel_url)
+                    async with httpx.AsyncClient(timeout=None) as client:
+                        async with aconnect_sse(
+                            client, "GET", self.channel_url
+                        ) as source:
+                            self._backoff = 1.0
+                            async for sse_event in source.aiter_sse():
+                                if sse_event.data:
+                                    await self.process_sse_message(sse_event.data)
             except (
                 httpx.ConnectError,
                 httpx.ReadError,

--- a/packages/webhook/src/github_webhook_mcp/smee_client.py
+++ b/packages/webhook/src/github_webhook_mcp/smee_client.py
@@ -122,7 +122,11 @@ class SmeeClient:
                 },
             )
 
-            if self.reactor and webhook_event.event_type == "pull_request" and webhook_event.action:
+            if (
+                self.reactor
+                and webhook_event.event_type == "pull_request"
+                and webhook_event.action
+            ):
                 pr_number = webhook_event.payload.get("number")
                 if isinstance(pr_number, int):
                     await self.reactor.on_pr_event(

--- a/packages/webhook/src/github_webhook_mcp/smee_client.py
+++ b/packages/webhook/src/github_webhook_mcp/smee_client.py
@@ -142,9 +142,7 @@ class SmeeClient:
                     conn_span.set_attribute("smee.channel_url", self.channel_url)
                     async with (
                         httpx.AsyncClient(timeout=None) as client,  # noqa: S113
-                        aconnect_sse(
-                            client, "GET", self.channel_url
-                        ) as source,
+                        aconnect_sse(client, "GET", self.channel_url) as source,
                     ):
                         self._backoff = 1.0
                         async for sse_event in source.aiter_sse():

--- a/packages/webhook/src/github_webhook_mcp/smee_client.py
+++ b/packages/webhook/src/github_webhook_mcp/smee_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 
 import httpx
@@ -82,9 +82,7 @@ class SmeeClient:
             )
 
             if not event.repo_full_name:
-                logger.debug(
-                    "Event has no repository, skipping: %s", event.x_github_delivery
-                )
+                logger.debug("Event has no repository, skipping: %s", event.x_github_delivery)
                 return
 
             span.set_attribute("smee.event_type", event.x_github_event or "unknown")
@@ -104,7 +102,7 @@ class SmeeClient:
                 )
 
             webhook_event = WebhookEvent(
-                received_at=datetime.now(timezone.utc),
+                received_at=datetime.now(UTC),
                 delivery_id=event.x_github_delivery or "",
                 repo=event.repo_full_name,
                 event_type=event.x_github_event or "unknown",
@@ -122,11 +120,7 @@ class SmeeClient:
                 },
             )
 
-            if (
-                self.reactor
-                and webhook_event.event_type == "pull_request"
-                and webhook_event.action
-            ):
+            if self.reactor and webhook_event.event_type == "pull_request" and webhook_event.action:
                 pr_number = webhook_event.payload.get("number")
                 if isinstance(pr_number, int):
                     await self.reactor.on_pr_event(
@@ -146,14 +140,16 @@ class SmeeClient:
                 logger.info("Connecting to Smee channel: %s", self.channel_url)
                 with _tracer.start_as_current_span("smee.connection") as conn_span:
                     conn_span.set_attribute("smee.channel_url", self.channel_url)
-                    async with httpx.AsyncClient(timeout=None) as client:
-                        async with aconnect_sse(
+                    async with (
+                        httpx.AsyncClient(timeout=None) as client,
+                        aconnect_sse(  # noqa: S113
                             client, "GET", self.channel_url
-                        ) as source:
-                            self._backoff = 1.0
-                            async for sse_event in source.aiter_sse():
-                                if sse_event.data:
-                                    await self.process_sse_message(sse_event.data)
+                        ) as source,
+                    ):
+                        self._backoff = 1.0
+                        async for sse_event in source.aiter_sse():
+                            if sse_event.data:
+                                await self.process_sse_message(sse_event.data)
             except (
                 httpx.ConnectError,
                 httpx.ReadError,

--- a/packages/webhook/src/github_webhook_mcp/storage.py
+++ b/packages/webhook/src/github_webhook_mcp/storage.py
@@ -21,8 +21,10 @@ def _get_tracer() -> trace.Tracer:
     global _tracer
     if _tracer is None:
         from .telemetry import get_tracer
+
         _tracer = get_tracer("webhook.storage")
     return _tracer
+
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS events (

--- a/packages/webhook/src/github_webhook_mcp/storage.py
+++ b/packages/webhook/src/github_webhook_mcp/storage.py
@@ -4,14 +4,25 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 import aiosqlite
+from opentelemetry import trace
 
 from .models import WebhookEvent
 
 logger = logging.getLogger(__name__)
+
+_tracer: trace.Tracer | None = None
+
+
+def _get_tracer() -> trace.Tracer:
+    global _tracer
+    if _tracer is None:
+        from .telemetry import get_tracer
+        _tracer = get_tracer("webhook.storage")
+    return _tracer
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS events (
@@ -68,27 +79,37 @@ class EventStore:
         Returns:
             ``True`` if the event was inserted, ``False`` if it was a duplicate.
         """
-        db = self._require_db()
-        try:
-            await db.execute(
-                """INSERT INTO events
-                   (received_at, delivery_id, repo, event_type, action, sender, payload)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    event.received_at.isoformat(),
-                    event.delivery_id,
-                    event.repo,
-                    event.event_type,
-                    event.action,
-                    event.sender,
-                    json.dumps(event.payload),
-                ),
-            )
-            await db.commit()
-            return True
-        except aiosqlite.IntegrityError:
-            logger.debug("Duplicate event ignored: %s", event.delivery_id)
-            return False
+        tracer = _get_tracer()
+        with tracer.start_as_current_span("eventstore.store_event") as span:
+            span.set_attribute("db.system", "sqlite")
+            span.set_attribute("db.operation", "INSERT")
+            span.set_attribute("event.delivery_id", event.delivery_id)
+            span.set_attribute("event.repo", event.repo)
+            span.set_attribute("event.type", event.event_type)
+            db = self._require_db()
+            try:
+                await db.execute(
+                    """INSERT INTO events
+                       (received_at, delivery_id, repo, event_type, action, sender, payload)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        event.received_at.isoformat(),
+                        event.delivery_id,
+                        event.repo,
+                        event.event_type,
+                        event.action,
+                        event.sender,
+                        json.dumps(event.payload),
+                    ),
+                )
+                await db.commit()
+                span.set_attribute("event.stored", True)
+                return True
+            except aiosqlite.IntegrityError:
+                logger.debug("Duplicate event ignored: %s", event.delivery_id)
+                span.set_attribute("event.stored", False)
+                span.set_attribute("event.duplicate", True)
+                return False
 
     async def get_events(
         self,
@@ -110,46 +131,53 @@ class EventStore:
         Returns:
             Matching events ordered by ``received_at`` descending.
         """
-        clauses: list[str] = []
-        params: list[str] = []
+        tracer = _get_tracer()
+        with tracer.start_as_current_span("eventstore.get_events") as span:
+            span.set_attribute("db.system", "sqlite")
+            span.set_attribute("db.operation", "SELECT")
 
-        if repo:
-            escaped = repo.replace("%", "\\%").replace("_", "\\_")
-            clauses.append("repo LIKE ? ESCAPE '\\'")
-            params.append(f"%{escaped}%")
-        if event_type:
-            clauses.append("event_type = ?")
-            params.append(event_type)
-        if action:
-            clauses.append("action = ?")
-            params.append(action)
-        if since:
-            clauses.append("received_at >= ?")
-            params.append(since.isoformat())
-        if sender:
-            clauses.append("sender = ?")
-            params.append(sender)
+            clauses: list[str] = []
+            params: list[str] = []
 
-        where = " AND ".join(clauses) if clauses else "1=1"
-        query = f"SELECT * FROM events WHERE {where} ORDER BY received_at DESC"
+            if repo:
+                escaped = repo.replace("%", "\\%").replace("_", "\\_")
+                clauses.append("repo LIKE ? ESCAPE '\\'")
+                params.append(f"%{escaped}%")
+            if event_type:
+                clauses.append("event_type = ?")
+                params.append(event_type)
+            if action:
+                clauses.append("action = ?")
+                params.append(action)
+            if since:
+                clauses.append("received_at >= ?")
+                params.append(since.isoformat())
+            if sender:
+                clauses.append("sender = ?")
+                params.append(sender)
 
-        db = self._require_db()
-        cursor = await db.execute(query, params)
-        rows = await cursor.fetchall()
+            where = " AND ".join(clauses) if clauses else "1=1"
+            query = f"SELECT * FROM events WHERE {where} ORDER BY received_at DESC"
 
-        return [
-            WebhookEvent(
-                id=row["id"],
-                received_at=datetime.fromisoformat(row["received_at"]),
-                delivery_id=row["delivery_id"],
-                repo=row["repo"],
-                event_type=row["event_type"],
-                action=row["action"],
-                sender=row["sender"],
-                payload=json.loads(row["payload"]),
-            )
-            for row in rows
-        ]
+            db = self._require_db()
+            cursor = await db.execute(query, params)
+            rows = await cursor.fetchall()
+
+            results = [
+                WebhookEvent(
+                    id=row["id"],
+                    received_at=datetime.fromisoformat(row["received_at"]),
+                    delivery_id=row["delivery_id"],
+                    repo=row["repo"],
+                    event_type=row["event_type"],
+                    action=row["action"],
+                    sender=row["sender"],
+                    payload=json.loads(row["payload"]),
+                )
+                for row in rows
+            ]
+            span.set_attribute("db.result_count", len(results))
+            return results
 
     async def prune(self, days: int = 7) -> int:
         """Delete events older than *days* days.

--- a/packages/webhook/src/github_webhook_mcp/telemetry.py
+++ b/packages/webhook/src/github_webhook_mcp/telemetry.py
@@ -1,0 +1,81 @@
+"""Webhook-specific OpenTelemetry helpers built on mcp_shared.telemetry."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, TypeVar
+
+from mcp_shared.telemetry import get_meter, get_tracer, init_telemetry
+from opentelemetry import trace
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+SERVICE_NAME = "webhook-mcp"
+
+_meter = get_meter(SERVICE_NAME)
+
+tool_calls_counter = _meter.create_counter(
+    "webhook.tool.calls",
+    description="Number of webhook MCP tool invocations",
+)
+
+events_received_counter = _meter.create_counter(
+    "webhook.events.received",
+    description="Number of webhook events received via SSE",
+)
+
+query_results_counter = _meter.create_counter(
+    "webhook.events.query_results",
+    description="Number of events returned per query",
+)
+
+
+def trace_tool_async(tool_name: str) -> Callable[[F], F]:
+    """Async-aware version of trace_tool for webhook MCP tool functions."""
+
+    def decorator(func: F) -> F:
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                tracer = get_tracer("mcp.tools")
+                with tracer.start_as_current_span(f"mcp.tool.{tool_name}") as span:
+                    span.set_attribute("mcp.tool.name", tool_name)
+                    tool_calls_counter.add(1, {"tool.name": tool_name})
+                    try:
+                        result = await func(*args, **kwargs)
+                        if isinstance(result, str):
+                            span.set_attribute("mcp.tool.result_length", len(result))
+                        return result
+                    except Exception as exc:
+                        span.record_exception(exc)
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        raise
+
+            return async_wrapper  # type: ignore[return-value]
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer("mcp.tools")
+            with tracer.start_as_current_span(f"mcp.tool.{tool_name}") as span:
+                span.set_attribute("mcp.tool.name", tool_name)
+                tool_calls_counter.add(1, {"tool.name": tool_name})
+                try:
+                    result = func(*args, **kwargs)
+                    if isinstance(result, str):
+                        span.set_attribute("mcp.tool.result_length", len(result))
+                    return result
+                except Exception as exc:
+                    span.record_exception(exc)
+                    span.set_status(trace.StatusCode.ERROR, str(exc))
+                    raise
+
+        return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def init_webhook_telemetry() -> None:
+    """Initialize OpenTelemetry for the webhook-mcp service."""
+    init_telemetry(SERVICE_NAME)

--- a/packages/webhook/src/github_webhook_mcp/telemetry.py
+++ b/packages/webhook/src/github_webhook_mcp/telemetry.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from mcp_shared.telemetry import get_meter, get_tracer, init_telemetry
 from opentelemetry import trace

--- a/packages/webhook/tests/conftest.py
+++ b/packages/webhook/tests/conftest.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 import pytest_asyncio
-
 from github_webhook_mcp.models import WebhookEvent
 from github_webhook_mcp.storage import EventStore
 
@@ -29,7 +28,7 @@ async def store(tmp_path: Path) -> AsyncIterator[EventStore]:
 @pytest.fixture
 def sample_event() -> WebhookEvent:
     return WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id="delivery-001",
         repo="mikelane/test-repo",
         event_type="pull_request",

--- a/packages/webhook/tests/conftest.py
+++ b/packages/webhook/tests/conftest.py
@@ -11,6 +11,12 @@ from github_webhook_mcp.models import WebhookEvent
 from github_webhook_mcp.storage import EventStore
 
 
+@pytest.fixture(autouse=True)
+def _disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable OpenTelemetry for all webhook tests."""
+    monkeypatch.setenv("ORACLE_TELEMETRY_ENABLED", "false")
+
+
 @pytest_asyncio.fixture
 async def store(tmp_path: Path) -> AsyncIterator[EventStore]:
     db_path = str(tmp_path / "test_events.db")

--- a/packages/webhook/tests/test_config.py
+++ b/packages/webhook/tests/test_config.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
-
 from github_webhook_mcp.config import Settings
+from pydantic import ValidationError
 
 
 def test_settings_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/webhook/tests/test_models.py
+++ b/packages/webhook/tests/test_models.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from github_webhook_mcp.models import SmeeEvent, WebhookEvent
-
 
 # --- WebhookEvent ---
 
@@ -13,7 +12,7 @@ from github_webhook_mcp.models import SmeeEvent, WebhookEvent
 def test_webhook_event_required_fields():
     """WebhookEvent can be constructed with all required fields."""
     event = WebhookEvent(
-        received_at=datetime(2025, 3, 15, tzinfo=timezone.utc),
+        received_at=datetime(2025, 3, 15, tzinfo=UTC),
         delivery_id="abc-123",
         repo="owner/repo",
         event_type="push",
@@ -29,7 +28,7 @@ def test_webhook_event_required_fields():
 def test_webhook_event_optional_fields_default_to_none():
     """Optional fields (id, action, sender) default to None."""
     event = WebhookEvent(
-        received_at=datetime(2025, 3, 15, tzinfo=timezone.utc),
+        received_at=datetime(2025, 3, 15, tzinfo=UTC),
         delivery_id="abc",
         repo="owner/repo",
         event_type="push",
@@ -45,7 +44,7 @@ def test_webhook_event_with_all_fields():
     """WebhookEvent populated with every field retains them."""
     event = WebhookEvent(
         id=42,
-        received_at=datetime(2025, 3, 15, 12, 0, 0, tzinfo=timezone.utc),
+        received_at=datetime(2025, 3, 15, 12, 0, 0, tzinfo=UTC),
         delivery_id="delivery-999",
         repo="mikelane/test-repo",
         event_type="pull_request",
@@ -55,7 +54,7 @@ def test_webhook_event_with_all_fields():
     )
 
     assert event.id == 42
-    assert event.received_at == datetime(2025, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert event.received_at == datetime(2025, 3, 15, 12, 0, 0, tzinfo=UTC)
     assert event.action == "opened"
     assert event.sender == "octocat"
 

--- a/packages/webhook/tests/test_reactor.py
+++ b/packages/webhook/tests/test_reactor.py
@@ -5,7 +5,6 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from github_webhook_mcp.reactor import PRReactor
 
 AUTO_REVIEW_REPO = "SayMoreAI/saymore"
@@ -92,9 +91,7 @@ async def test_spawn_review_success_logs_complete(
     mock_review_process.communicate = AsyncMock(return_value=(b"output", b""))
     mock_review_process.returncode = 0
 
-    with patch(
-        "asyncio.create_subprocess_exec", return_value=mock_review_process
-    ) as mock_exec:
+    with patch("asyncio.create_subprocess_exec", return_value=mock_review_process) as mock_exec:
         await reactor._spawn_review(AUTO_REVIEW_REPO, 42)
 
         mock_exec.assert_called_once_with(

--- a/packages/webhook/tests/test_reactor.py
+++ b/packages/webhook/tests/test_reactor.py
@@ -92,12 +92,17 @@ async def test_spawn_review_success_logs_complete(
     mock_review_process.communicate = AsyncMock(return_value=(b"output", b""))
     mock_review_process.returncode = 0
 
-    with patch("asyncio.create_subprocess_exec", return_value=mock_review_process) as mock_exec:
+    with patch(
+        "asyncio.create_subprocess_exec", return_value=mock_review_process
+    ) as mock_exec:
         await reactor._spawn_review(AUTO_REVIEW_REPO, 42)
 
         mock_exec.assert_called_once_with(
-            "claude", "-p", "/review-pr 42",
-            "--cwd", "/tmp/fake-saymore",
+            "claude",
+            "-p",
+            "/review-pr 42",
+            "--cwd",
+            "/tmp/fake-saymore",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/packages/webhook/tests/test_server.py
+++ b/packages/webhook/tests/test_server.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
 import pytest_asyncio
-
 from github_webhook_mcp.models import WebhookEvent
 from github_webhook_mcp.server import (
     _require_store,
@@ -47,7 +46,7 @@ def _make_webhook_event(
     if payload_extra:
         payload.update(payload_extra)
     return WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id=delivery_id,
         repo=repo,
         event_type=event_type,
@@ -176,7 +175,7 @@ async def test_get_notifications_summary_no_double_space_when_action_is_none(
 ) -> None:
     """When action is None the summary must not contain a double space."""
     webhook_event = WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id="d-no-action",
         repo="mikelane/test-repo",
         event_type="push",
@@ -483,7 +482,7 @@ async def test_get_new_prs_filters_by_repo(store: EventStore) -> None:
 @pytest.mark.asyncio
 async def test_get_new_prs_filters_by_since(store: EventStore) -> None:
     """When since is specified, only PRs after that time are returned."""
-    old_time = datetime(2020, 6, 1, tzinfo=timezone.utc)
+    old_time = datetime(2020, 6, 1, tzinfo=UTC)
     old_webhook_event = WebhookEvent(
         received_at=old_time,
         delivery_id="d-pr-old",
@@ -506,7 +505,7 @@ async def test_get_new_prs_filters_by_since(store: EventStore) -> None:
     await store.store_event(old_webhook_event)
 
     recent_webhook_event = WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id="d-pr-new",
         repo="mikelane/test-repo",
         event_type="pull_request",
@@ -526,7 +525,7 @@ async def test_get_new_prs_filters_by_since(store: EventStore) -> None:
     )
     await store.store_event(recent_webhook_event)
 
-    since_iso = datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat()
+    since_iso = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
     raw_response = await get_new_prs(since=since_iso)
     opened_prs = json.loads(raw_response)
 

--- a/packages/webhook/tests/test_server.py
+++ b/packages/webhook/tests/test_server.py
@@ -171,7 +171,9 @@ async def test_get_notifications_returns_all(store: EventStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_notifications_summary_no_double_space_when_action_is_none(store: EventStore) -> None:
+async def test_get_notifications_summary_no_double_space_when_action_is_none(
+    store: EventStore,
+) -> None:
     """When action is None the summary must not contain a double space."""
     webhook_event = WebhookEvent(
         received_at=datetime.now(timezone.utc),

--- a/packages/webhook/tests/test_signature.py
+++ b/packages/webhook/tests/test_signature.py
@@ -22,9 +22,7 @@ def test_valid_signature_returns_true() -> None:
 
 def test_invalid_signature_returns_false() -> None:
     payload = b'{"action": "opened"}'
-    signature = (
-        "sha256=0000000000000000000000000000000000000000000000000000000000000000"
-    )
+    signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000"
 
     assert verify_signature(payload, signature, SECRET) is False
 

--- a/packages/webhook/tests/test_signature.py
+++ b/packages/webhook/tests/test_signature.py
@@ -22,7 +22,9 @@ def test_valid_signature_returns_true() -> None:
 
 def test_invalid_signature_returns_false() -> None:
     payload = b'{"action": "opened"}'
-    signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+    signature = (
+        "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+    )
 
     assert verify_signature(payload, signature, SECRET) is False
 

--- a/packages/webhook/tests/test_smee_client.py
+++ b/packages/webhook/tests/test_smee_client.py
@@ -22,9 +22,9 @@ def _make_smee_envelope(
 ) -> dict[str, Any]:
     """Build a Smee SSE envelope dict matching Smee.io's format."""
     payload_bytes = json.dumps(body).encode()
-    signature = "sha256=" + hmac.new(
-        SECRET.encode(), payload_bytes, hashlib.sha256
-    ).hexdigest()
+    signature = (
+        "sha256=" + hmac.new(SECRET.encode(), payload_bytes, hashlib.sha256).hexdigest()
+    )
     return {
         "body": body,
         "x-github-event": event,
@@ -62,7 +62,8 @@ async def test_valid_event_is_stored(client: SmeeClient, store: EventStore) -> N
 
 @pytest.mark.asyncio
 async def test_event_with_bad_signature_is_still_stored(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     """Smee.io re-serializes JSON, so signatures never match.
     Events are stored anyway since the channel URL is the security boundary."""
@@ -86,7 +87,8 @@ async def test_event_with_bad_signature_is_still_stored(
 
 @pytest.mark.asyncio
 async def test_event_missing_repo_is_skipped(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     body: dict[str, Any] = {"action": "completed"}  # no "repository" key
     smee_envelope = _make_smee_envelope(body, event="check_run", delivery="d-norepo")
@@ -116,7 +118,9 @@ async def test_pr_event_notifies_reactor(store: EventStore) -> None:
         "sender": {"login": "dev"},
         "pull_request": {"number": 77, "title": "New feature"},
     }
-    smee_envelope = _make_smee_envelope(body, event="pull_request", delivery="d-pr-notify")
+    smee_envelope = _make_smee_envelope(
+        body, event="pull_request", delivery="d-pr-notify"
+    )
 
     await client.process_sse_message(json.dumps(smee_envelope))
 
@@ -125,7 +129,8 @@ async def test_pr_event_notifies_reactor(store: EventStore) -> None:
 
 @pytest.mark.asyncio
 async def test_non_json_sse_data_is_skipped(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     """Non-JSON SSE data (e.g. keepalive messages) is silently skipped."""
     await client.process_sse_message("this is not json")
@@ -136,7 +141,8 @@ async def test_non_json_sse_data_is_skipped(
 
 @pytest.mark.asyncio
 async def test_json_without_body_key_is_skipped(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     """SSE data that parses as JSON but has no 'body' key is skipped."""
     await client.process_sse_message(json.dumps({"timestamp": 12345}))
@@ -163,7 +169,9 @@ async def test_non_pr_event_does_not_notify_reactor(store: EventStore) -> None:
         "repository": {"full_name": "mikelane/repo"},
         "sender": {"login": "bot"},
     }
-    smee_envelope = _make_smee_envelope(body, event="push", delivery="d-push-no-reactor")
+    smee_envelope = _make_smee_envelope(
+        body, event="push", delivery="d-push-no-reactor"
+    )
 
     await client.process_sse_message(json.dumps(smee_envelope))
 
@@ -193,7 +201,9 @@ async def test_pr_event_without_number_does_not_notify_reactor(
         "repository": {"full_name": "mikelane/repo"},
         "sender": {"login": "dev"},
     }
-    smee_envelope = _make_smee_envelope(body, event="pull_request", delivery="d-pr-no-num")
+    smee_envelope = _make_smee_envelope(
+        body, event="pull_request", delivery="d-pr-no-num"
+    )
 
     await client.process_sse_message(json.dumps(smee_envelope))
 
@@ -204,7 +214,8 @@ async def test_pr_event_without_number_does_not_notify_reactor(
 
 @pytest.mark.asyncio
 async def test_backoff_resets_after_successful_event(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     """After a successful process_sse_message, _backoff resets to 1.0."""
     client._backoff = 16.0  # simulate previous reconnection backoff
@@ -224,7 +235,8 @@ async def test_backoff_resets_after_successful_event(
 
 @pytest.mark.asyncio
 async def test_event_without_signature_is_stored(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     """Events with no x-hub-signature-256 header are stored without error."""
     smee_envelope = {
@@ -248,7 +260,8 @@ async def test_event_without_signature_is_stored(
 
 @pytest.mark.asyncio
 async def test_missing_optional_headers_use_fallbacks(
-    client: SmeeClient, store: EventStore,
+    client: SmeeClient,
+    store: EventStore,
 ) -> None:
     """Events missing x-github-event and x-github-delivery use fallbacks."""
     smee_envelope = {

--- a/packages/webhook/tests/test_smee_client.py
+++ b/packages/webhook/tests/test_smee_client.py
@@ -7,7 +7,6 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from github_webhook_mcp.reactor import PRReactor
 from github_webhook_mcp.smee_client import SmeeClient
 from github_webhook_mcp.storage import EventStore
@@ -22,9 +21,7 @@ def _make_smee_envelope(
 ) -> dict[str, Any]:
     """Build a Smee SSE envelope dict matching Smee.io's format."""
     payload_bytes = json.dumps(body).encode()
-    signature = (
-        "sha256=" + hmac.new(SECRET.encode(), payload_bytes, hashlib.sha256).hexdigest()
-    )
+    signature = "sha256=" + hmac.new(SECRET.encode(), payload_bytes, hashlib.sha256).hexdigest()
     return {
         "body": body,
         "x-github-event": event,
@@ -118,9 +115,7 @@ async def test_pr_event_notifies_reactor(store: EventStore) -> None:
         "sender": {"login": "dev"},
         "pull_request": {"number": 77, "title": "New feature"},
     }
-    smee_envelope = _make_smee_envelope(
-        body, event="pull_request", delivery="d-pr-notify"
-    )
+    smee_envelope = _make_smee_envelope(body, event="pull_request", delivery="d-pr-notify")
 
     await client.process_sse_message(json.dumps(smee_envelope))
 
@@ -169,9 +164,7 @@ async def test_non_pr_event_does_not_notify_reactor(store: EventStore) -> None:
         "repository": {"full_name": "mikelane/repo"},
         "sender": {"login": "bot"},
     }
-    smee_envelope = _make_smee_envelope(
-        body, event="push", delivery="d-push-no-reactor"
-    )
+    smee_envelope = _make_smee_envelope(body, event="push", delivery="d-push-no-reactor")
 
     await client.process_sse_message(json.dumps(smee_envelope))
 
@@ -201,9 +194,7 @@ async def test_pr_event_without_number_does_not_notify_reactor(
         "repository": {"full_name": "mikelane/repo"},
         "sender": {"login": "dev"},
     }
-    smee_envelope = _make_smee_envelope(
-        body, event="pull_request", delivery="d-pr-no-num"
-    )
+    smee_envelope = _make_smee_envelope(body, event="pull_request", delivery="d-pr-no-num")
 
     await client.process_sse_message(json.dumps(smee_envelope))
 

--- a/packages/webhook/tests/test_storage.py
+++ b/packages/webhook/tests/test_storage.py
@@ -16,7 +16,9 @@ async def test_store_initializes_database(store: EventStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_event_and_retrieve(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_store_event_and_retrieve(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     stored = await store.store_event(sample_event)
     assert stored is True
 
@@ -27,7 +29,9 @@ async def test_store_event_and_retrieve(store: EventStore, sample_event: Webhook
 
 
 @pytest.mark.asyncio
-async def test_duplicate_delivery_id_is_ignored(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_duplicate_delivery_id_is_ignored(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     await store.store_event(sample_event)
     stored_again = await store.store_event(sample_event)
 
@@ -37,7 +41,9 @@ async def test_duplicate_delivery_id_is_ignored(store: EventStore, sample_event:
 
 
 @pytest.mark.asyncio
-async def test_query_by_repo_filter(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_by_repo_filter(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     await store.store_event(sample_event)
 
     other = sample_event.model_copy(
@@ -51,7 +57,9 @@ async def test_query_by_repo_filter(store: EventStore, sample_event: WebhookEven
 
 
 @pytest.mark.asyncio
-async def test_query_by_event_type(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_by_event_type(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     await store.store_event(sample_event)
 
     issue_event = sample_event.model_copy(
@@ -64,7 +72,9 @@ async def test_query_by_event_type(store: EventStore, sample_event: WebhookEvent
 
 
 @pytest.mark.asyncio
-async def test_repo_filter_escapes_sql_wildcards(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_repo_filter_escapes_sql_wildcards(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     await store.store_event(sample_event)
 
     percent_matches = await store.get_events(repo="%")
@@ -88,13 +98,17 @@ async def test_query_by_since(store: EventStore, sample_event: WebhookEvent) -> 
     await store.store_event(old_event)
     await store.store_event(sample_event)
 
-    recent_events = await store.get_events(since=datetime(2024, 1, 1, tzinfo=timezone.utc))
+    recent_events = await store.get_events(
+        since=datetime(2024, 1, 1, tzinfo=timezone.utc)
+    )
     assert len(recent_events) == 1
     assert recent_events[0].delivery_id == "delivery-001"
 
 
 @pytest.mark.asyncio
-async def test_prune_removes_old_events(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_prune_removes_old_events(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     old_event = sample_event.model_copy(
         update={
             "delivery_id": "delivery-ancient",
@@ -113,7 +127,9 @@ async def test_prune_removes_old_events(store: EventStore, sample_event: Webhook
 
 
 @pytest.mark.asyncio
-async def test_prune_preserves_recent_events(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_prune_preserves_recent_events(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     await store.store_event(sample_event)
 
     deleted = await store.prune(days=7)
@@ -141,7 +157,9 @@ async def test_require_db_raises_before_initialize() -> None:
 
 
 @pytest.mark.asyncio
-async def test_query_by_action_filter(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_by_action_filter(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """Filtering by action returns only events with that action."""
     await store.store_event(sample_event)  # action="opened"
 
@@ -164,7 +182,9 @@ async def test_query_by_action_filter(store: EventStore, sample_event: WebhookEv
 
 
 @pytest.mark.asyncio
-async def test_query_by_sender_filter(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_by_sender_filter(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """Filtering by sender returns only events from that sender."""
     await store.store_event(sample_event)  # sender="octocat"
 
@@ -189,21 +209,33 @@ async def test_query_by_sender_filter(store: EventStore, sample_event: WebhookEv
 
 
 @pytest.mark.asyncio
-async def test_query_with_multiple_filters(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_with_multiple_filters(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """Multiple filters are AND-combined."""
-    await store.store_event(sample_event)  # repo=mikelane/test-repo, event_type=pull_request, action=opened
+    await store.store_event(
+        sample_event
+    )  # repo=mikelane/test-repo, event_type=pull_request, action=opened
 
     issue_event = sample_event.model_copy(
-        update={"delivery_id": "delivery-issue", "event_type": "issues", "action": "opened"}
+        update={
+            "delivery_id": "delivery-issue",
+            "event_type": "issues",
+            "action": "opened",
+        }
     )
     await store.store_event(issue_event)
 
-    opened_pr_events = await store.get_events(event_type="pull_request", action="opened")
+    opened_pr_events = await store.get_events(
+        event_type="pull_request", action="opened"
+    )
     assert len(opened_pr_events) == 1
     assert opened_pr_events[0].event_type == "pull_request"
     assert opened_pr_events[0].action == "opened"
 
-    closed_pr_events = await store.get_events(event_type="pull_request", action="closed")
+    closed_pr_events = await store.get_events(
+        event_type="pull_request", action="closed"
+    )
     assert len(closed_pr_events) == 0
 
 
@@ -211,7 +243,9 @@ async def test_query_with_multiple_filters(store: EventStore, sample_event: Webh
 
 
 @pytest.mark.asyncio
-async def test_query_no_filters_returns_all(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_no_filters_returns_all(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """Calling get_events with no filters returns all stored events."""
     await store.store_event(sample_event)
     second = sample_event.model_copy(update={"delivery_id": "delivery-second"})
@@ -225,7 +259,9 @@ async def test_query_no_filters_returns_all(store: EventStore, sample_event: Web
 
 
 @pytest.mark.asyncio
-async def test_query_results_ordered_by_received_at_descending(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_query_results_ordered_by_received_at_descending(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """Events are returned newest first."""
     old = sample_event.model_copy(
         update={
@@ -251,7 +287,9 @@ async def test_query_results_ordered_by_received_at_descending(store: EventStore
 
 
 @pytest.mark.asyncio
-async def test_store_event_preserves_payload(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_store_event_preserves_payload(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """The full payload dict survives the store/retrieve roundtrip."""
     await store.store_event(sample_event)
 
@@ -266,7 +304,9 @@ async def test_store_event_preserves_payload(store: EventStore, sample_event: We
 
 
 @pytest.mark.asyncio
-async def test_close_is_idempotent(store: EventStore, sample_event: WebhookEvent) -> None:
+async def test_close_is_idempotent(
+    store: EventStore, sample_event: WebhookEvent
+) -> None:
     """Calling close on a store that has no db set does not raise."""
     from github_webhook_mcp.storage import EventStore
 

--- a/packages/webhook/tests/test_storage.py
+++ b/packages/webhook/tests/test_storage.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
-
 from github_webhook_mcp.models import WebhookEvent
 from github_webhook_mcp.storage import EventStore
 
@@ -16,9 +15,7 @@ async def test_store_initializes_database(store: EventStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_event_and_retrieve(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_store_event_and_retrieve(store: EventStore, sample_event: WebhookEvent) -> None:
     stored = await store.store_event(sample_event)
     assert stored is True
 
@@ -41,9 +38,7 @@ async def test_duplicate_delivery_id_is_ignored(
 
 
 @pytest.mark.asyncio
-async def test_query_by_repo_filter(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_query_by_repo_filter(store: EventStore, sample_event: WebhookEvent) -> None:
     await store.store_event(sample_event)
 
     other = sample_event.model_copy(
@@ -57,9 +52,7 @@ async def test_query_by_repo_filter(
 
 
 @pytest.mark.asyncio
-async def test_query_by_event_type(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_query_by_event_type(store: EventStore, sample_event: WebhookEvent) -> None:
     await store.store_event(sample_event)
 
     issue_event = sample_event.model_copy(
@@ -92,27 +85,23 @@ async def test_query_by_since(store: EventStore, sample_event: WebhookEvent) -> 
     old_event = sample_event.model_copy(
         update={
             "delivery_id": "delivery-old",
-            "received_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "received_at": datetime(2020, 1, 1, tzinfo=UTC),
         }
     )
     await store.store_event(old_event)
     await store.store_event(sample_event)
 
-    recent_events = await store.get_events(
-        since=datetime(2024, 1, 1, tzinfo=timezone.utc)
-    )
+    recent_events = await store.get_events(since=datetime(2024, 1, 1, tzinfo=UTC))
     assert len(recent_events) == 1
     assert recent_events[0].delivery_id == "delivery-001"
 
 
 @pytest.mark.asyncio
-async def test_prune_removes_old_events(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_prune_removes_old_events(store: EventStore, sample_event: WebhookEvent) -> None:
     old_event = sample_event.model_copy(
         update={
             "delivery_id": "delivery-ancient",
-            "received_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "received_at": datetime(2020, 1, 1, tzinfo=UTC),
         }
     )
     await store.store_event(old_event)
@@ -127,9 +116,7 @@ async def test_prune_removes_old_events(
 
 
 @pytest.mark.asyncio
-async def test_prune_preserves_recent_events(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_prune_preserves_recent_events(store: EventStore, sample_event: WebhookEvent) -> None:
     await store.store_event(sample_event)
 
     deleted = await store.prune(days=7)
@@ -157,9 +144,7 @@ async def test_require_db_raises_before_initialize() -> None:
 
 
 @pytest.mark.asyncio
-async def test_query_by_action_filter(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_query_by_action_filter(store: EventStore, sample_event: WebhookEvent) -> None:
     """Filtering by action returns only events with that action."""
     await store.store_event(sample_event)  # action="opened"
 
@@ -182,9 +167,7 @@ async def test_query_by_action_filter(
 
 
 @pytest.mark.asyncio
-async def test_query_by_sender_filter(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_query_by_sender_filter(store: EventStore, sample_event: WebhookEvent) -> None:
     """Filtering by sender returns only events from that sender."""
     await store.store_event(sample_event)  # sender="octocat"
 
@@ -209,9 +192,7 @@ async def test_query_by_sender_filter(
 
 
 @pytest.mark.asyncio
-async def test_query_with_multiple_filters(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_query_with_multiple_filters(store: EventStore, sample_event: WebhookEvent) -> None:
     """Multiple filters are AND-combined."""
     await store.store_event(
         sample_event
@@ -226,16 +207,12 @@ async def test_query_with_multiple_filters(
     )
     await store.store_event(issue_event)
 
-    opened_pr_events = await store.get_events(
-        event_type="pull_request", action="opened"
-    )
+    opened_pr_events = await store.get_events(event_type="pull_request", action="opened")
     assert len(opened_pr_events) == 1
     assert opened_pr_events[0].event_type == "pull_request"
     assert opened_pr_events[0].action == "opened"
 
-    closed_pr_events = await store.get_events(
-        event_type="pull_request", action="closed"
-    )
+    closed_pr_events = await store.get_events(event_type="pull_request", action="closed")
     assert len(closed_pr_events) == 0
 
 
@@ -243,9 +220,7 @@ async def test_query_with_multiple_filters(
 
 
 @pytest.mark.asyncio
-async def test_query_no_filters_returns_all(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_query_no_filters_returns_all(store: EventStore, sample_event: WebhookEvent) -> None:
     """Calling get_events with no filters returns all stored events."""
     await store.store_event(sample_event)
     second = sample_event.model_copy(update={"delivery_id": "delivery-second"})
@@ -266,13 +241,13 @@ async def test_query_results_ordered_by_received_at_descending(
     old = sample_event.model_copy(
         update={
             "delivery_id": "delivery-old",
-            "received_at": datetime(2023, 1, 1, tzinfo=timezone.utc),
+            "received_at": datetime(2023, 1, 1, tzinfo=UTC),
         }
     )
     new = sample_event.model_copy(
         update={
             "delivery_id": "delivery-new",
-            "received_at": datetime(2025, 6, 1, tzinfo=timezone.utc),
+            "received_at": datetime(2025, 6, 1, tzinfo=UTC),
         }
     )
     await store.store_event(old)
@@ -287,9 +262,7 @@ async def test_query_results_ordered_by_received_at_descending(
 
 
 @pytest.mark.asyncio
-async def test_store_event_preserves_payload(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_store_event_preserves_payload(store: EventStore, sample_event: WebhookEvent) -> None:
     """The full payload dict survives the store/retrieve roundtrip."""
     await store.store_event(sample_event)
 
@@ -304,9 +277,7 @@ async def test_store_event_preserves_payload(
 
 
 @pytest.mark.asyncio
-async def test_close_is_idempotent(
-    store: EventStore, sample_event: WebhookEvent
-) -> None:
+async def test_close_is_idempotent(store: EventStore, sample_event: WebhookEvent) -> None:
     """Calling close on a store that has no db set does not raise."""
     from github_webhook_mcp.storage import EventStore
 

--- a/packages/webhook/tests/test_telemetry.py
+++ b/packages/webhook/tests/test_telemetry.py
@@ -6,14 +6,13 @@ import hashlib
 import hmac
 import json
 from collections.abc import AsyncIterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
-
 from github_webhook_mcp.models import WebhookEvent
 from github_webhook_mcp.server import (
     get_ci_status,
@@ -51,7 +50,7 @@ def _make_webhook_event(
     if payload_extra:
         payload.update(payload_extra)
     return WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id=delivery_id,
         repo=repo,
         event_type=event_type,
@@ -285,9 +284,7 @@ async def test_smee_client_increments_events_received_counter(
         "sender": {"login": "octocat"},
     }
     payload_bytes = json.dumps(body).encode()
-    signature = (
-        "sha256=" + hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
-    )
+    signature = "sha256=" + hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
     envelope = json.dumps(
         {
             "body": body,
@@ -304,9 +301,7 @@ async def test_smee_client_increments_events_received_counter(
         call_args_list.append(args)
         original_add(*args, **kwargs)
 
-    with patch.object(
-        telemetry.events_received_counter, "add", side_effect=tracking_add
-    ):
+    with patch.object(telemetry.events_received_counter, "add", side_effect=tracking_add):
         await client.process_sse_message(envelope)
 
     assert len(call_args_list) == 1
@@ -335,9 +330,7 @@ async def test_smee_client_does_not_increment_counter_for_non_json(
         call_args_list.append(args)
         original_add(*args, **kwargs)
 
-    with patch.object(
-        telemetry.events_received_counter, "add", side_effect=tracking_add
-    ):
+    with patch.object(telemetry.events_received_counter, "add", side_effect=tracking_add):
         await client.process_sse_message("not json")
 
     assert len(call_args_list) == 0
@@ -351,7 +344,7 @@ async def test_eventstore_stores_and_retrieves_with_spans(
     store: EventStore,
 ) -> None:
     event = WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id="d-store-tel-1",
         repo="mikelane/test-repo",
         event_type="push",
@@ -373,7 +366,7 @@ async def test_eventstore_handles_duplicates_with_spans(
     store: EventStore,
 ) -> None:
     event = WebhookEvent(
-        received_at=datetime.now(timezone.utc),
+        received_at=datetime.now(UTC),
         delivery_id="d-store-tel-dup",
         repo="mikelane/test-repo",
         event_type="push",

--- a/packages/webhook/tests/test_telemetry.py
+++ b/packages/webhook/tests/test_telemetry.py
@@ -181,9 +181,7 @@ async def test_get_new_prs_returns_correct_result_with_decorator(
 async def test_get_notifications_returns_correct_result_with_decorator(
     store: EventStore,
 ) -> None:
-    await store.store_event(
-        _make_webhook_event("d-tel-5", "push", "push")
-    )
+    await store.store_event(_make_webhook_event("d-tel-5", "push", "push"))
 
     result = await get_notifications()
     parsed = json.loads(result)
@@ -287,15 +285,17 @@ async def test_smee_client_increments_events_received_counter(
         "sender": {"login": "octocat"},
     }
     payload_bytes = json.dumps(body).encode()
-    signature = "sha256=" + hmac.new(
-        secret.encode(), payload_bytes, hashlib.sha256
-    ).hexdigest()
-    envelope = json.dumps({
-        "body": body,
-        "x-github-event": "pull_request",
-        "x-github-delivery": "d-smee-tel-1",
-        "x-hub-signature-256": signature,
-    })
+    signature = (
+        "sha256=" + hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+    )
+    envelope = json.dumps(
+        {
+            "body": body,
+            "x-github-event": "pull_request",
+            "x-github-delivery": "d-smee-tel-1",
+            "x-hub-signature-256": signature,
+        }
+    )
 
     call_args_list: list[tuple[Any, ...]] = []
     original_add = telemetry.events_received_counter.add
@@ -456,7 +456,5 @@ async def test_reactor_traces_spawn_review_cli_not_found() -> None:
 
     reactor = PRReactor(repo_path="/tmp/fake")
 
-    with patch(
-        "asyncio.create_subprocess_exec", side_effect=FileNotFoundError
-    ):
+    with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError):
         await reactor._spawn_review("SayMoreAI/saymore", 42)

--- a/packages/webhook/tests/test_telemetry.py
+++ b/packages/webhook/tests/test_telemetry.py
@@ -1,0 +1,462 @@
+"""Tests for webhook OpenTelemetry instrumentation."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from github_webhook_mcp.models import WebhookEvent
+from github_webhook_mcp.server import (
+    get_ci_status,
+    get_new_prs,
+    get_notifications,
+    get_pending_reviews,
+    get_review_feedback,
+    init_server,
+)
+from github_webhook_mcp.storage import EventStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path: Path) -> AsyncIterator[EventStore]:
+    event_store = EventStore(str(tmp_path / "test_telemetry.db"))
+    await event_store.initialize()
+    init_server(event_store)
+    yield event_store
+    await event_store.close()
+
+
+def _make_webhook_event(
+    delivery_id: str,
+    event_type: str,
+    action: str,
+    repo: str = "mikelane/test-repo",
+    sender: str = "octocat",
+    payload_extra: dict[str, Any] | None = None,
+) -> WebhookEvent:
+    payload = {
+        "action": action,
+        "repository": {"full_name": repo},
+        "sender": {"login": sender},
+    }
+    if payload_extra:
+        payload.update(payload_extra)
+    return WebhookEvent(
+        received_at=datetime.now(timezone.utc),
+        delivery_id=delivery_id,
+        repo=repo,
+        event_type=event_type,
+        action=action,
+        sender=sender,
+        payload=payload,
+    )
+
+
+# --- trace_tool_async: decorated tools still return correct results ---
+
+
+@pytest.mark.asyncio
+async def test_get_pending_reviews_returns_correct_result_with_decorator(
+    store: EventStore,
+) -> None:
+    await store.store_event(
+        _make_webhook_event(
+            "d-tel-1",
+            "pull_request",
+            "review_requested",
+            payload_extra={
+                "requested_reviewer": {"login": "mikelane"},
+                "pull_request": {
+                    "number": 10,
+                    "title": "Telemetry PR",
+                    "html_url": "https://github.com/mikelane/test-repo/pull/10",
+                    "user": {"login": "octocat"},
+                },
+            },
+        )
+    )
+
+    result = await get_pending_reviews()
+    parsed = json.loads(result)
+
+    assert len(parsed) == 1
+    assert parsed[0]["number"] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_review_feedback_returns_correct_result_with_decorator(
+    store: EventStore,
+) -> None:
+    await store.store_event(
+        _make_webhook_event(
+            "d-tel-2",
+            "pull_request_review",
+            "submitted",
+            payload_extra={
+                "pull_request": {
+                    "number": 20,
+                    "html_url": "https://github.com/mikelane/test-repo/pull/20",
+                    "user": {"login": "author"},
+                },
+                "review": {
+                    "state": "approved",
+                    "body": "LGTM",
+                    "user": {"login": "reviewer"},
+                },
+            },
+        )
+    )
+
+    result = await get_review_feedback(pr_number=20, repo="test-repo")
+    parsed = json.loads(result)
+
+    assert len(parsed) == 1
+    assert parsed[0]["state"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_get_ci_status_returns_correct_result_with_decorator(
+    store: EventStore,
+) -> None:
+    await store.store_event(
+        _make_webhook_event(
+            "d-tel-3",
+            "check_run",
+            "completed",
+            payload_extra={
+                "check_run": {
+                    "name": "lint",
+                    "conclusion": "failure",
+                    "html_url": "https://github.com/mikelane/test-repo/runs/1",
+                    "pull_requests": [],
+                },
+            },
+        )
+    )
+
+    result = await get_ci_status()
+    parsed = json.loads(result)
+
+    assert len(parsed) == 1
+    assert parsed[0]["name"] == "lint"
+
+
+@pytest.mark.asyncio
+async def test_get_new_prs_returns_correct_result_with_decorator(
+    store: EventStore,
+) -> None:
+    await store.store_event(
+        _make_webhook_event(
+            "d-tel-4",
+            "pull_request",
+            "opened",
+            payload_extra={
+                "pull_request": {
+                    "number": 30,
+                    "title": "New feature",
+                    "html_url": "https://github.com/mikelane/test-repo/pull/30",
+                    "user": {"login": "dev"},
+                },
+            },
+        )
+    )
+
+    result = await get_new_prs()
+    parsed = json.loads(result)
+
+    assert len(parsed) == 1
+    assert parsed[0]["number"] == 30
+
+
+@pytest.mark.asyncio
+async def test_get_notifications_returns_correct_result_with_decorator(
+    store: EventStore,
+) -> None:
+    await store.store_event(
+        _make_webhook_event("d-tel-5", "push", "push")
+    )
+
+    result = await get_notifications()
+    parsed = json.loads(result)
+
+    assert len(parsed) == 1
+    assert parsed[0]["event_type"] == "push"
+
+
+# --- tool_calls_counter: incremented on each tool invocation ---
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_counter_increments_on_get_pending_reviews(
+    store: EventStore,
+) -> None:
+    from github_webhook_mcp import telemetry
+
+    call_args_list: list[tuple[Any, ...]] = []
+    original_add = telemetry.tool_calls_counter.add
+
+    def tracking_add(*args: Any, **kwargs: Any) -> None:
+        call_args_list.append(args)
+        original_add(*args, **kwargs)
+
+    with patch.object(telemetry.tool_calls_counter, "add", side_effect=tracking_add):
+        await get_pending_reviews()
+
+    assert len(call_args_list) == 1
+    assert call_args_list[0][0] == 1
+    assert call_args_list[0][1]["tool.name"] == "get_pending_reviews"
+
+
+# --- query_results_counter: records result counts ---
+
+
+@pytest.mark.asyncio
+async def test_query_results_counter_records_count_for_get_notifications(
+    store: EventStore,
+) -> None:
+    await store.store_event(_make_webhook_event("d-qr-1", "push", "push"))
+    await store.store_event(_make_webhook_event("d-qr-2", "issues", "opened"))
+
+    from github_webhook_mcp import server
+
+    call_args_list: list[tuple[Any, ...]] = []
+    original_add = server.query_results_counter.add
+
+    def tracking_add(*args: Any, **kwargs: Any) -> None:
+        call_args_list.append(args)
+        original_add(*args, **kwargs)
+
+    with patch.object(server.query_results_counter, "add", side_effect=tracking_add):
+        await get_notifications()
+
+    assert len(call_args_list) == 1
+    assert call_args_list[0][0] == 2
+    assert call_args_list[0][1]["tool.name"] == "get_notifications"
+
+
+@pytest.mark.asyncio
+async def test_query_results_counter_records_zero_when_no_results(
+    store: EventStore,
+) -> None:
+    from github_webhook_mcp import server
+
+    call_args_list: list[tuple[Any, ...]] = []
+    original_add = server.query_results_counter.add
+
+    def tracking_add(*args: Any, **kwargs: Any) -> None:
+        call_args_list.append(args)
+        original_add(*args, **kwargs)
+
+    with patch.object(server.query_results_counter, "add", side_effect=tracking_add):
+        await get_pending_reviews()
+
+    assert len(call_args_list) == 1
+    assert call_args_list[0][0] == 0
+
+
+# --- SmeeClient: events_received_counter ---
+
+
+@pytest.mark.asyncio
+async def test_smee_client_increments_events_received_counter(
+    store: EventStore,
+) -> None:
+    from github_webhook_mcp import telemetry
+    from github_webhook_mcp.smee_client import SmeeClient
+
+    secret = "test-secret"
+    client = SmeeClient(
+        channel_url="https://smee.io/test",
+        webhook_secret=secret,
+        store=store,
+    )
+
+    body = {
+        "action": "opened",
+        "number": 1,
+        "repository": {"full_name": "mikelane/repo"},
+        "sender": {"login": "octocat"},
+    }
+    payload_bytes = json.dumps(body).encode()
+    signature = "sha256=" + hmac.new(
+        secret.encode(), payload_bytes, hashlib.sha256
+    ).hexdigest()
+    envelope = json.dumps({
+        "body": body,
+        "x-github-event": "pull_request",
+        "x-github-delivery": "d-smee-tel-1",
+        "x-hub-signature-256": signature,
+    })
+
+    call_args_list: list[tuple[Any, ...]] = []
+    original_add = telemetry.events_received_counter.add
+
+    def tracking_add(*args: Any, **kwargs: Any) -> None:
+        call_args_list.append(args)
+        original_add(*args, **kwargs)
+
+    with patch.object(
+        telemetry.events_received_counter, "add", side_effect=tracking_add
+    ):
+        await client.process_sse_message(envelope)
+
+    assert len(call_args_list) == 1
+    assert call_args_list[0][0] == 1
+    assert call_args_list[0][1]["event.type"] == "pull_request"
+    assert call_args_list[0][1]["event.repo"] == "mikelane/repo"
+
+
+@pytest.mark.asyncio
+async def test_smee_client_does_not_increment_counter_for_non_json(
+    store: EventStore,
+) -> None:
+    from github_webhook_mcp import telemetry
+    from github_webhook_mcp.smee_client import SmeeClient
+
+    client = SmeeClient(
+        channel_url="https://smee.io/test",
+        webhook_secret="secret",
+        store=store,
+    )
+
+    call_args_list: list[tuple[Any, ...]] = []
+    original_add = telemetry.events_received_counter.add
+
+    def tracking_add(*args: Any, **kwargs: Any) -> None:
+        call_args_list.append(args)
+        original_add(*args, **kwargs)
+
+    with patch.object(
+        telemetry.events_received_counter, "add", side_effect=tracking_add
+    ):
+        await client.process_sse_message("not json")
+
+    assert len(call_args_list) == 0
+
+
+# --- EventStore: spans don't break store/retrieve ---
+
+
+@pytest.mark.asyncio
+async def test_eventstore_stores_and_retrieves_with_spans(
+    store: EventStore,
+) -> None:
+    event = WebhookEvent(
+        received_at=datetime.now(timezone.utc),
+        delivery_id="d-store-tel-1",
+        repo="mikelane/test-repo",
+        event_type="push",
+        action="push",
+        sender="octocat",
+        payload={"ref": "refs/heads/main"},
+    )
+
+    stored = await store.store_event(event)
+    assert stored is True
+
+    events = await store.get_events()
+    assert len(events) == 1
+    assert events[0].delivery_id == "d-store-tel-1"
+
+
+@pytest.mark.asyncio
+async def test_eventstore_handles_duplicates_with_spans(
+    store: EventStore,
+) -> None:
+    event = WebhookEvent(
+        received_at=datetime.now(timezone.utc),
+        delivery_id="d-store-tel-dup",
+        repo="mikelane/test-repo",
+        event_type="push",
+        action="push",
+        sender="octocat",
+        payload={"ref": "refs/heads/main"},
+    )
+
+    first = await store.store_event(event)
+    second = await store.store_event(event)
+
+    assert first is True
+    assert second is False
+
+
+# --- PRReactor: spans don't break reactor behavior ---
+
+
+@pytest.mark.asyncio
+async def test_reactor_traces_immediate_review_on_opened() -> None:
+    from github_webhook_mcp.reactor import PRReactor
+
+    reactor = PRReactor(
+        auto_review_repo="SayMoreAI/saymore",
+        debounce_seconds=900,
+        repo_path="/tmp/fake",
+    )
+
+    with patch.object(reactor, "_spawn_review", new_callable=AsyncMock) as mock:
+        await reactor.on_pr_event("SayMoreAI/saymore", 42, "opened")
+        mock.assert_called_once_with("SayMoreAI/saymore", 42)
+
+
+@pytest.mark.asyncio
+async def test_reactor_traces_skipped_non_matching_repo() -> None:
+    from github_webhook_mcp.reactor import PRReactor
+
+    reactor = PRReactor(
+        auto_review_repo="SayMoreAI/saymore",
+        debounce_seconds=900,
+        repo_path="/tmp/fake",
+    )
+
+    with patch.object(reactor, "_spawn_review", new_callable=AsyncMock) as mock:
+        await reactor.on_pr_event("other/repo", 1, "opened")
+        mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reactor_traces_spawn_review_success() -> None:
+    from github_webhook_mcp.reactor import PRReactor
+
+    reactor = PRReactor(repo_path="/tmp/fake")
+
+    mock_process = AsyncMock()
+    mock_process.communicate = AsyncMock(return_value=(b"ok", b""))
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        await reactor._spawn_review("SayMoreAI/saymore", 42)
+
+
+@pytest.mark.asyncio
+async def test_reactor_traces_spawn_review_failure() -> None:
+    from github_webhook_mcp.reactor import PRReactor
+
+    reactor = PRReactor(repo_path="/tmp/fake")
+
+    mock_process = AsyncMock()
+    mock_process.communicate = AsyncMock(return_value=(b"", b"err"))
+    mock_process.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        await reactor._spawn_review("SayMoreAI/saymore", 42)
+
+
+@pytest.mark.asyncio
+async def test_reactor_traces_spawn_review_cli_not_found() -> None:
+    from github_webhook_mcp.reactor import PRReactor
+
+    reactor = PRReactor(repo_path="/tmp/fake")
+
+    with patch(
+        "asyncio.create_subprocess_exec", side_effect=FileNotFoundError
+    ):
+        await reactor._spawn_review("SayMoreAI/saymore", 42)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,73 @@ members = ["packages/*"]
 
 [tool.uv.sources]
 mcp-shared = { workspace = true }
+
+[dependency-groups]
+dev = [
+    "ruff>=0.9",
+    "mypy>=1.14",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # bugbear
+    "SIM",  # simplify
+    "S",    # bandit security
+    "N",    # pep8-naming
+    "C4",   # flake8-comprehensions
+    "PT",   # pytest style
+    "RET",  # return statements
+    "ARG",  # unused arguments
+    "PTH",  # use pathlib
+    "ERA",  # commented-out code
+    "PL",   # pylint (C, E, R, W)
+    "RUF",  # ruff-specific
+    "PERF", # performance
+    "T20",  # no print statements
+    "DTZ",  # datetime timezone
+    "A",    # builtin shadowing
+    "TCH",  # type-checking imports
+    "FBT",  # boolean trap
+]
+ignore = [
+    "S101",    # assert used — fine in tests
+    "S603",    # subprocess without shell=True — we do this intentionally
+    "S607",    # partial executable path — acceptable for tool commands
+    "PLR0913", # too many arguments — some functions legitimately need them
+    "PLR2004", # magic value comparison — too noisy in tests
+    "FBT001",  # boolean positional arg — too strict for simple flags
+    "FBT002",  # boolean default value — too strict for simple flags
+    "FBT003",  # boolean positional value in call — too noisy
+    "PLC0415", # import outside top-level — deliberate lazy import pattern in server.py
+    "PLW0603", # global statement — used for session tracking
+    "TC001",   # typing-only first-party import — future cleanup
+    "TC002",   # typing-only third-party import — future cleanup
+    "TC003",   # typing-only stdlib import — future cleanup
+    "S608",    # hardcoded SQL — we build queries intentionally in store methods
+    "PLR0911", # too many return statements — some handlers need branching
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**" = [
+    "S101",    # assert is the point of tests
+    "S105",    # hardcoded passwords in test data
+    "S106",    # hardcoded passwords in test fixtures
+    "S108",    # temp file paths in tests
+    "ARG",     # unused args common in fixtures
+    "PLR2004", # magic values fine in tests
+    "PT004",   # fixture doesn't return — fine
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,4 @@ python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
+warn_unused_ignores = false  # @mcp.tool() typed locally but not in CI

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [manifest]
 members = [
@@ -567,6 +572,59 @@ dev = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.73.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -951,6 +1009,11 @@ cli = [
 name = "mcp-shared"
 version = "0.1.0"
 source = { editable = "packages/shared" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -960,6 +1023,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "opentelemetry-api", specifier = ">=1.20" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
 ]
@@ -1048,6 +1114,75 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/7f/b9e60435cfcc7590fa87436edad6822240dddbc184643a2a005301cc31f4/opentelemetry_exporter_otlp_proto_grpc-1.40.0.tar.gz", hash = "sha256:bd4015183e40b635b3dab8da528b27161ba83bf4ef545776b196f0fb4ec47740", size = 25759, upload-time = "2026-03-04T14:17:24.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/6f/7ee0980afcbdcd2d40362da16f7f9796bd083bf7f0b8e038abfbc0300f5d/opentelemetry_exporter_otlp_proto_grpc-1.40.0-py3-none-any.whl", hash = "sha256:2aa0ca53483fe0cf6405087a7491472b70335bc5c7944378a0a8e72e86995c52", size = 20304, upload-time = "2026-03-04T14:17:05.942Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
 ]
 
 [[package]]
@@ -1162,6 +1297,21 @@ requires-dist = [
     { name = "zstandard", specifier = ">=0.23" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
 
 [[package]]
 name = "py-key-value-aio"

--- a/uv.lock
+++ b/uv.lock
@@ -437,6 +437,20 @@ name = "dev-mcp-tools"
 version = "0.1.0"
 source = { virtual = "." }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.14" },
+    { name = "ruff", specifier = ">=0.9" },
+]
+
 [[package]]
 name = "distro"
 version = "1.9.0"
@@ -1269,13 +1283,11 @@ dev = [
     { name = "behave" },
     { name = "coverage" },
     { name = "hypothesis" },
-    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-gremlins" },
     { name = "pytest-mock" },
     { name = "pytest-test-categories" },
-    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1286,13 +1298,11 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0" },
     { name = "mcp-shared", editable = "packages/shared" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-gremlins", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14" },
     { name = "pytest-test-categories", marker = "extra == 'dev'", specifier = ">=1.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "watchfiles", specifier = ">=1.0" },
     { name = "zstandard", specifier = ">=0.23" },
 ]


### PR DESCRIPTION
## Summary

- **Agent Analytics subsystem** — tracks tool call sequences, file co-access patterns, and session profiles to surface actionable insights via a new `oracle_insights` MCP tool
- **OpenTelemetry instrumentation** — traces, metrics, and logs across all 3 packages (Oracle, Webhook, Shared), emitting to SigNoz at `signoz.local:4317`

## What's new

### Analytics (Layer 1 of Smarter Agent Awareness)
- 3 new SQLite tables: `tool_sequences`, `file_coaccess`, `session_profiles`
- `AnalyticsTracker` — records tool sequences and file co-access pairs on every `_log()` call
- `SessionAggregator` — computes session profiles on session boundary detection
- `InsightsGenerator` — queries accumulated data for actionable recommendations
- New MCP tool: `oracle_insights` (8 total tools now)

### OpenTelemetry
- `mcp_shared.telemetry` module with `init_telemetry()`, `get_tracer()`, `get_meter()`, `trace_tool()` decorator
- All 7 Oracle tools + new `oracle_insights` instrumented with `@trace_tool` decorator
- All 5 Webhook tools + SmeeClient SSE lifecycle + EventStore + PRReactor instrumented
- Metrics: `oracle.tool.calls`, `oracle.cache.hits`, `oracle.tokens.saved` counters
- Disabled via `ORACLE_TELEMETRY_ENABLED=false` for tests

## Test plan

- [ ] 461 Oracle tests pass (verified)
- [ ] 94 Webhook tests pass (verified)
- [ ] Coverage ≥ 95% (98% actual)
- [ ] Ruff lint clean across all packages
- [ ] `oracle_insights` returns formatted output with co-access pairs, re-read candidates, cache hit trends, and common tool sequences
- [ ] OTel spans appear in SigNoz when `ORACLE_TELEMETRY_ENABLED=true`

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)